### PR TITLE
Project/tag scoping + recency/importance ranking + entity-vector fix + O(N2) contradiction cap

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 node_modules/
 dist/
+coverage/
 *.sqlite
 *.sqlite-wal
 *.sqlite-shm

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,30 @@
 # Changelog
 
+## [2.3.0] — 2026-06-21
+
+Retrieval-quality + correctness release. 194 → **233 tests**. No breaking schema change — entity embeddings are added on write and idempotently backfilled on next open.
+
+### Added — project / tags scoping for `memory_search` and `memory_recall`
+
+Both main retrieval tools now accept optional `project` and `tags` filters (previously only `insights`/`reflect` did), so multi-project stores can scope retrieval. Applied as cheap source-table predicates; absent filters leave behavior unchanged. Because `project`/`tags` live on learnings + decisions, an active filter excludes entity/observation rows.
+
+### Added — recency / usage / importance ranking boost (hybrid mode)
+
+`memory_search` hybrid (RRF) results are now multiplied by a conservative, tunable boost (exp recency decay ~30d half-life + saturating usage + clamped importance, always ≥1, max +40%; disable via weights=0 or `MEMORY_RANK_*`). The `importance` column was previously written but never read for ranking. The boost cannot override a clear textual-relevance gap, and pure `fts`/`vector` single-mode ordering is untouched.
+
+### Fixed — vector search over entities returned nothing
+
+`memory_search({mode:"vector", types:["entity"]})` silently returned 0 results because entities were never embedded. Entities now embed `name + summary` atomically on create/observe (same single-transaction pattern as learnings), with a summary-change refresh and an idempotent boot-time backfill for legacy rows.
+
+### Performance — contradiction scanner per-entity cap
+
+`memory_contradictions` now bounds its O(N²) intra-entity self-join with `maxObservationsPerEntity` (default 200, range 2–2000), keeping the freshest live + embedded observations per entity, so a long-lived entity with thousands of observations no longer hits a quadratic cliff.
+
+### Internal
+
+- `memory_recall` description clarified as FTS5-only (use `memory_search` for hybrid).
+- Added `test:coverage` script + critical-path tests (RRF consensus, `asOf` window boundaries, supersede inverted-window, contradiction scope).
+
 ## [2.2.0] — 2026-06-20
 
 Portability + lifecycle release. 21 → **25 tools**, 159 → **194 tests**. No breaking schema change (one additive index, created via `IF NOT EXISTS` on the next open of any existing DB).

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@studiomeyer/local-memory-mcp",
-  "version": "2.1.0",
+  "version": "2.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@studiomeyer/local-memory-mcp",
-      "version": "2.1.0",
+      "version": "2.2.0",
       "license": "MIT",
       "dependencies": {
         "@huggingface/transformers": "^4.2.0",
@@ -21,6 +21,7 @@
       "devDependencies": {
         "@types/better-sqlite3": "^7.6.13",
         "@types/node": "^22.10.0",
+        "@vitest/coverage-v8": "^2.1.9",
         "tsx": "^4.22.3",
         "typescript": "^5.7.2",
         "vitest": "^2.1.8"
@@ -28,6 +29,77 @@
       "engines": {
         "node": ">=18"
       }
+    },
+    "node_modules/@ampproject/remapping": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@ampproject/remapping/-/remapping-2.3.0.tgz",
+      "integrity": "sha512-30iZtAPgz+LTIYoeivqYo853f02jBYSd5uGnGpkFV0M3xOt9aN73erkgYAmZU43x4VfqcnLxW9Kpg3R5LC4YYw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@jridgewell/gen-mapping": "^0.3.5",
+        "@jridgewell/trace-mapping": "^0.3.24"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@babel/helper-string-parser": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.29.7.tgz",
+      "integrity": "sha512-Pb5ijPrZ89GDH8223L4UP8i6QApWxs04RbPQJTeWDV0/keR2E36MeKnyr6LYmUUvqRRI+Iv87SuF1W6ErINzYw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-validator-identifier": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.29.7.tgz",
+      "integrity": "sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/parser": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.7.tgz",
+      "integrity": "sha512-hnORnjP/1P/zFEndoeX+n+t1RwWRJiJpM/jO7FW32Kn9r5+sJB2JWOdYo4L6k78j15eCwY3Gm/7364B1EMwtNg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^7.29.7"
+      },
+      "bin": {
+        "parser": "bin/babel-parser.js"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@babel/types": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.7.tgz",
+      "integrity": "sha512-4zBIxpPzowiZpusoFkyGVwakdRJUyuH5PxQ/PrqghfdFWWasvnCdPfQXHrenDai+gyLARulZjZowCOj6fjT4pA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-string-parser": "^7.29.7",
+        "@babel/helper-validator-identifier": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@bcoe/v8-coverage": {
+      "version": "0.2.3",
+      "resolved": "https://registry.npmjs.org/@bcoe/v8-coverage/-/v8-coverage-0.2.3.tgz",
+      "integrity": "sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@emnapi/runtime": {
       "version": "1.10.0",
@@ -986,12 +1058,72 @@
         "url": "https://opencollective.com/libvips"
       }
     },
+    "node_modules/@isaacs/cliui": {
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/@isaacs/cliui/-/cliui-8.0.2.tgz",
+      "integrity": "sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "string-width": "^5.1.2",
+        "string-width-cjs": "npm:string-width@^4.2.0",
+        "strip-ansi": "^7.0.1",
+        "strip-ansi-cjs": "npm:strip-ansi@^6.0.1",
+        "wrap-ansi": "^8.1.0",
+        "wrap-ansi-cjs": "npm:wrap-ansi@^7.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@istanbuljs/schema": {
+      "version": "0.1.6",
+      "resolved": "https://registry.npmjs.org/@istanbuljs/schema/-/schema-0.1.6.tgz",
+      "integrity": "sha512-+Sg6GCR/wy1oSmQDFq4LQDAhm3ETKnorxN+y5nbLULOR3P0c14f2Wurzj3/xqPXtasLFfHd5iRFQ7AJt4KH2cw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@jridgewell/gen-mapping": {
+      "version": "0.3.13",
+      "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz",
+      "integrity": "sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.0",
+        "@jridgewell/trace-mapping": "^0.3.24"
+      }
+    },
+    "node_modules/@jridgewell/resolve-uri": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
+      "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
     "node_modules/@jridgewell/sourcemap-codec": {
       "version": "1.5.5",
       "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
       "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@jridgewell/trace-mapping": {
+      "version": "0.3.31",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz",
+      "integrity": "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/resolve-uri": "^3.1.0",
+        "@jridgewell/sourcemap-codec": "^1.4.14"
+      }
     },
     "node_modules/@modelcontextprotocol/sdk": {
       "version": "1.29.0",
@@ -1031,6 +1163,17 @@
         "zod": {
           "optional": false
         }
+      }
+    },
+    "node_modules/@pkgjs/parseargs": {
+      "version": "0.11.0",
+      "resolved": "https://registry.npmjs.org/@pkgjs/parseargs/-/parseargs-0.11.0.tgz",
+      "integrity": "sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=14"
       }
     },
     "node_modules/@protobufjs/aspromise": {
@@ -1472,6 +1615,39 @@
         "undici-types": "~6.21.0"
       }
     },
+    "node_modules/@vitest/coverage-v8": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/coverage-v8/-/coverage-v8-2.1.9.tgz",
+      "integrity": "sha512-Z2cOr0ksM00MpEfyVE8KXIYPEcBFxdbLSs56L8PO0QQMxt/6bDj45uQfxoc96v05KW3clk7vvgP0qfDit9DmfQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@ampproject/remapping": "^2.3.0",
+        "@bcoe/v8-coverage": "^0.2.3",
+        "debug": "^4.3.7",
+        "istanbul-lib-coverage": "^3.2.2",
+        "istanbul-lib-report": "^3.0.1",
+        "istanbul-lib-source-maps": "^5.0.6",
+        "istanbul-reports": "^3.1.7",
+        "magic-string": "^0.30.12",
+        "magicast": "^0.3.5",
+        "std-env": "^3.8.0",
+        "test-exclude": "^7.0.1",
+        "tinyrainbow": "^1.2.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@vitest/browser": "2.1.9",
+        "vitest": "2.1.9"
+      },
+      "peerDependenciesMeta": {
+        "@vitest/browser": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@vitest/expect": {
       "version": "2.1.9",
       "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-2.1.9.tgz",
@@ -1640,6 +1816,32 @@
         }
       }
     },
+    "node_modules/ansi-regex": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.2.tgz",
+      "integrity": "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-regex?sponsor=1"
+      }
+    },
+    "node_modules/ansi-styles": {
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.3.tgz",
+      "integrity": "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
     "node_modules/assertion-error": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
@@ -1648,6 +1850,16 @@
       "license": "MIT",
       "engines": {
         "node": ">=12"
+      }
+    },
+    "node_modules/balanced-match": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
+      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "18 || 20 || >=22"
       }
     },
     "node_modules/base64-js": {
@@ -1734,6 +1946,19 @@
       "integrity": "sha512-d0II/GO9uf9lfUHH2BQsjxzRJZBdsjgsBiW4BvhWk/3qoKwQFjIDVN19PfX8F2D/r9PCMTtLWjYVCFrpeYUzsw==",
       "deprecated": "Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.",
       "license": "MIT"
+    },
+    "node_modules/brace-expansion": {
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
+      "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^4.0.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
     },
     "node_modules/buffer": {
       "version": "5.7.1",
@@ -1839,6 +2064,26 @@
       "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.4.tgz",
       "integrity": "sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg==",
       "license": "ISC"
+    },
+    "node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/content-disposition": {
       "version": "1.1.0",
@@ -2034,10 +2279,24 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/eastasianwidth": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/eastasianwidth/-/eastasianwidth-0.2.0.tgz",
+      "integrity": "sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/ee-first": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
       "integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==",
+      "license": "MIT"
+    },
+    "node_modules/emoji-regex": {
+      "version": "9.2.2",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-9.2.2.tgz",
+      "integrity": "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/encodeurl": {
@@ -2336,6 +2595,23 @@
       "integrity": "sha512-MI1qs7Lo4Syw0EOzUl0xjs2lsoeqFku44KpngfIduHBYvzm8h2+7K8YMQh1JtVVVrUvhLpNwqVi4DERegUJhPQ==",
       "license": "Apache-2.0"
     },
+    "node_modules/foreground-child": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-3.3.1.tgz",
+      "integrity": "sha512-gIXjKqtFuWEgzFRJA9WCQeSJLZDjgJUOMCMzxtvFq/37KojM1BFGufqsCy0r4qSQmYLsZYMeyRqzIWOMup03sw==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "cross-spawn": "^7.0.6",
+        "signal-exit": "^4.0.1"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
     "node_modules/forwarded": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.2.0.tgz",
@@ -2427,6 +2703,61 @@
       "integrity": "sha512-SyHy3T1v2NUXn29OsWdxmK6RwHD+vkj3v8en8AOBZ1wBQ/hCAQ5bAQTD02kW4W9tUp/3Qh6J8r9EvntiyCmOOw==",
       "license": "MIT"
     },
+    "node_modules/glob": {
+      "version": "10.5.0",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-10.5.0.tgz",
+      "integrity": "sha512-DfXN8DfhJ7NH3Oe7cFmu3NCu1wKbkReJ8TorzSAFbSKrlNaQSKfIzqYqVY8zlbs2NLBbWpRiU52GX2PbaBVNkg==",
+      "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "foreground-child": "^3.1.0",
+        "jackspeak": "^3.1.2",
+        "minimatch": "^9.0.4",
+        "minipass": "^7.1.2",
+        "package-json-from-dist": "^1.0.0",
+        "path-scurry": "^1.11.1"
+      },
+      "bin": {
+        "glob": "dist/esm/bin.mjs"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/glob/node_modules/balanced-match": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/glob/node_modules/brace-expansion": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.1.tgz",
+      "integrity": "sha512-WR1cURNjuvBLMZBMbqM0UoE+WAfdUcEV1ccD8PVBVOI+Z3ND4+SZbN8RsfT2bMuG1qwz5RFvPukSZm5fF2D5eA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0"
+      }
+    },
+    "node_modules/glob/node_modules/minimatch": {
+      "version": "9.0.9",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.9.tgz",
+      "integrity": "sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^2.0.2"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
     "node_modules/global-agent": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/global-agent/-/global-agent-3.0.0.tgz",
@@ -2478,6 +2809,16 @@
       "integrity": "sha512-Y8T4vYhEfwJOTbouREvG+3XDsjr8E3kIr7uf+JZ0BYloFsttiHU0WfvANVsR7TxNUJa/WpCnw/Ino/p+DeBhBQ==",
       "license": "ISC"
     },
+    "node_modules/has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/has-property-descriptors": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/has-property-descriptors/-/has-property-descriptors-1.0.2.tgz",
@@ -2522,6 +2863,13 @@
       "engines": {
         "node": ">=16.9.0"
       }
+    },
+    "node_modules/html-escaper": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-2.0.2.tgz",
+      "integrity": "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/http-errors": {
       "version": "2.0.1",
@@ -2609,6 +2957,16 @@
         "node": ">= 0.10"
       }
     },
+    "node_modules/is-fullwidth-code-point": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/is-promise": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-4.0.0.tgz",
@@ -2620,6 +2978,76 @@
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
       "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
       "license": "ISC"
+    },
+    "node_modules/istanbul-lib-coverage": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-3.2.2.tgz",
+      "integrity": "sha512-O8dpsF+r0WV/8MNRKfnmrtCWhuKjxrq2w+jpzBL5UZKTi2LeVWnWOmWRxFlesJONmc+wLAGvKQZEOanko0LFTg==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/istanbul-lib-report": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-report/-/istanbul-lib-report-3.0.1.tgz",
+      "integrity": "sha512-GCfE1mtsHGOELCU8e/Z7YWzpmybrx/+dSTfLrvY8qRmaY6zXTKWn6WQIjaAFw069icm6GVMNkgu0NzI4iPZUNw==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "istanbul-lib-coverage": "^3.0.0",
+        "make-dir": "^4.0.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/istanbul-lib-source-maps": {
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-source-maps/-/istanbul-lib-source-maps-5.0.6.tgz",
+      "integrity": "sha512-yg2d+Em4KizZC5niWhQaIomgf5WlL4vOOjZ5xGCmF8SnPE/mDWWXgvRExdcpCgh9lLRRa1/fSYp2ymmbJ1pI+A==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@jridgewell/trace-mapping": "^0.3.23",
+        "debug": "^4.1.1",
+        "istanbul-lib-coverage": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/istanbul-reports": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-3.2.0.tgz",
+      "integrity": "sha512-HGYWWS/ehqTV3xN10i23tkPkpH46MLCIMFNCaaKNavAXTF1RkqxawEPtnjnGZ6XKSInBKkiOA5BKS+aZiY3AvA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "html-escaper": "^2.0.0",
+        "istanbul-lib-report": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/jackspeak": {
+      "version": "3.4.3",
+      "resolved": "https://registry.npmjs.org/jackspeak/-/jackspeak-3.4.3.tgz",
+      "integrity": "sha512-OGlZQpz2yfahA/Rd1Y8Cd9SIEsqvXkLVoSw/cgwhnhFMDbsQFeZYoJJ7bIZBS9BcamUW96asq/npPWugM+RQBw==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "@isaacs/cliui": "^8.0.2"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      },
+      "optionalDependencies": {
+        "@pkgjs/parseargs": "^0.11.0"
+      }
     },
     "node_modules/jose": {
       "version": "6.2.2",
@@ -2661,6 +3089,13 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/lru-cache": {
+      "version": "10.4.3",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
+      "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/magic-string": {
       "version": "0.30.21",
       "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
@@ -2669,6 +3104,34 @@
       "license": "MIT",
       "dependencies": {
         "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
+    "node_modules/magicast": {
+      "version": "0.3.5",
+      "resolved": "https://registry.npmjs.org/magicast/-/magicast-0.3.5.tgz",
+      "integrity": "sha512-L0WhttDl+2BOsybvEOLK7fW3UA0OQ0IQ2d6Zl2x/a6vVRs3bAY0ECOSHHeL5jD+SbOpOCUEi0y1DgHEn9Qn1AQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.25.4",
+        "@babel/types": "^7.25.4",
+        "source-map-js": "^1.2.0"
+      }
+    },
+    "node_modules/make-dir": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-4.0.0.tgz",
+      "integrity": "sha512-hXdUTZYIVOt1Ex//jAQi+wTZZpUpwBj/0QsOzqegb3rGMMeJiSEu5xLHnYfBrRV4RH2+OCSOO95Is/7x1WJ4bw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "semver": "^7.5.3"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/matcher": {
@@ -2750,6 +3213,22 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/minimatch": {
+      "version": "10.2.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.5.tgz",
+      "integrity": "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "brace-expansion": "^5.0.5"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
     "node_modules/minimist": {
       "version": "1.2.8",
       "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
@@ -2757,6 +3236,16 @@
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/minipass": {
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.3.tgz",
+      "integrity": "sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
       }
     },
     "node_modules/mkdirp-classic": {
@@ -2911,6 +3400,13 @@
       "integrity": "sha512-BOoomdHYmNRL5r4iQ4bMvsl2t0/hzVQ3OM3PHD0gxeXu1PmggqBv3puZicEUVOA3AtHHYmqZtjMj9FOfGrATTw==",
       "license": "MIT"
     },
+    "node_modules/package-json-from-dist": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/package-json-from-dist/-/package-json-from-dist-1.0.1.tgz",
+      "integrity": "sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==",
+      "dev": true,
+      "license": "BlueOak-1.0.0"
+    },
     "node_modules/parseurl": {
       "version": "1.3.3",
       "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
@@ -2927,6 +3423,23 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/path-scurry": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-1.11.1.tgz",
+      "integrity": "sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "lru-cache": "^10.2.0",
+        "minipass": "^5.0.0 || ^6.0.2 || ^7.0.0"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/path-to-regexp": {
@@ -3490,6 +4003,19 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/signal-exit": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
+      "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
     "node_modules/simple-concat": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/simple-concat/-/simple-concat-1.0.1.tgz",
@@ -3661,6 +4187,110 @@
         "safe-buffer": "~5.2.0"
       }
     },
+    "node_modules/string-width": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-5.1.2.tgz",
+      "integrity": "sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "eastasianwidth": "^0.2.0",
+        "emoji-regex": "^9.2.2",
+        "strip-ansi": "^7.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/string-width-cjs": {
+      "name": "string-width",
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/string-width-cjs/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/string-width-cjs/node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/string-width-cjs/node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/strip-ansi": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.2.0.tgz",
+      "integrity": "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^6.2.2"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/strip-ansi?sponsor=1"
+      }
+    },
+    "node_modules/strip-ansi-cjs": {
+      "name": "strip-ansi",
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/strip-ansi-cjs/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/strip-json-comments": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
@@ -3668,6 +4298,19 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/tar-fs": {
@@ -3696,6 +4339,21 @@
       },
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/test-exclude": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/test-exclude/-/test-exclude-7.0.2.tgz",
+      "integrity": "sha512-u9E6A+ZDYdp7a4WnarkXPZOx8Ilz46+kby6p1yZ8zsGTz9gYa6FIS7lj2oezzNKmtdyyJNNmmXDppga5GB7kSw==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "@istanbuljs/schema": "^0.1.2",
+        "glob": "^10.4.1",
+        "minimatch": "^10.2.2"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/tinybench": {
@@ -4465,6 +5123,104 @@
       },
       "bin": {
         "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/wrap-ansi": {
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-8.1.0.tgz",
+      "integrity": "sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^6.1.0",
+        "string-width": "^5.0.1",
+        "strip-ansi": "^7.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/wrap-ansi-cjs": {
+      "name": "wrap-ansi",
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+      "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/wrap-ansi-cjs/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/wrap-ansi-cjs/node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/wrap-ansi-cjs/node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/wrap-ansi-cjs/node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/wrap-ansi-cjs/node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
       },
       "engines": {
         "node": ">=8"

--- a/package.json
+++ b/package.json
@@ -54,6 +54,7 @@
     "dev": "tsx src/server.ts",
     "test": "MEMORY_EMBED_MOCK=1 vitest run",
     "test:watch": "MEMORY_EMBED_MOCK=1 vitest",
+    "test:coverage": "MEMORY_EMBED_MOCK=1 vitest run --coverage",
     "typecheck": "tsc --noEmit",
     "prepublishOnly": "npm run build"
   },
@@ -67,6 +68,7 @@
   "devDependencies": {
     "@types/better-sqlite3": "^7.6.13",
     "@types/node": "^22.10.0",
+    "@vitest/coverage-v8": "^2.1.9",
     "tsx": "^4.22.3",
     "typescript": "^5.7.2",
     "vitest": "^2.1.8"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@studiomeyer/local-memory-mcp",
-  "version": "2.2.0",
+  "version": "2.3.0",
   "description": "Persistent local memory for any MCP client. SQLite + FTS5 + sqlite-vec hybrid retrieval, bi-temporal asOf queries, contradiction detection, LLM-free reflection. Multilingual embeddings. Knowledge Graph. No cloud, no API keys.",
   "type": "module",
   "main": "dist/server.js",

--- a/src/db/vector.ts
+++ b/src/db/vector.ts
@@ -192,19 +192,22 @@ export function vectorStatus(): { enabled: boolean; error: string | null } {
  * `entityObserve`). Living in the db layer matches the dependency direction
  * `tools/* → db/* → lib/*`.
  *
- * F10 cleanup (Critic R1): removed the dead `'entity'` arm from the
- * contentType union since entities themselves are not embedded — only their
- * observations are. The single source of truth for "what is embedded" is now
- * the union itself.
+ * v2.3.0 (entity embedding bugfix): `'entity'` is now a first-class embeddable
+ * content type. Earlier releases deliberately excluded it — the reasoning was
+ * that an entity row carries only a name+summary while its attached
+ * observations hold the semantic surface. But `searchSchema` advertised
+ * 'entity' in its `types` enum AND `mode:'vector'` accepted it, so
+ * `memory_search({mode:'vector', types:['entity']})` always returned zero — a
+ * silent capability lie. We close that by embedding `name + summary` on
+ * create/observe (atomic F4 pattern) plus a one-shot boot backfill
+ * (`backfillEntityEmbeddings`). Entities stay reachable through their
+ * observations too — the entity vector is an additional recall surface, not a
+ * replacement.
  *
- * R2-7 doc-strengthen (Critic R2): the DB column is just a TEXT aux column
- * with no constraint, so a raw-SQL caller could write any string into it.
- * Do NOT extend this union — entity-level embedding is intentionally not
- * supported because entity rows carry only a name+summary while their
- * attached observations carry the semantic surface. If you need entity
- * recall, embed the observations.
+ * The DB column is still an unconstrained TEXT aux column; the union is the
+ * single source of truth for what the tool layer is allowed to write.
  */
-export type EmbeddingContentType = 'learning' | 'decision' | 'observation';
+export type EmbeddingContentType = 'learning' | 'decision' | 'observation' | 'entity';
 
 /**
  * @deprecated Since v2.0.0 R2 — prefer `prepareEmbedding` + `writeEmbeddingSync`
@@ -349,6 +352,79 @@ export function deleteEmbeddings(contentIds: string[], db: Database): void {
   } catch (err) {
     logger.warn(`[vector] cascade delete failed: ${err instanceof Error ? err.message : String(err)}`);
   }
+}
+
+/**
+ * Build the canonical embeddable text for an entity (v2.3.0). Mirrors the
+ * surface the FTS5 `entities_*` triggers index: name as the title, then the
+ * summary plus the entity_type. Concatenated into one passage so the vector
+ * captures the same signal a text query would hit. Exported so the create /
+ * observe write paths and the backfill all derive the string identically —
+ * one source of truth for "what an entity embeds to".
+ */
+export function entityEmbedText(name: string, summary: string | null, entityType: string): string {
+  return `${name} ${summary ?? ''} ${entityType}`.trim();
+}
+
+/**
+ * One-shot boot backfill for entity embeddings (v2.3.0 entity-embedding fix).
+ *
+ * Pre-v2.3.0 entities were never embedded, so on an existing user DB every
+ * entity row is missing from `embeddings` and `memory_search({mode:'vector',
+ * types:['entity']})` returns nothing for them. New writes embed inline; this
+ * closes the gap for rows created before the upgrade.
+ *
+ * Idempotent + cheap: it only touches entities with NO embeddings row, so on a
+ * fully-backfilled DB the candidate query returns zero and we no-op. Embeddings
+ * are computed in one batched forward pass (`prepareEmbeddingBatch`) and written
+ * inside a single transaction. A failure to embed a given row leaves it without
+ * a vector (it stays FTS-searchable) and the next boot retries it — same
+ * graceful-degradation contract as the rest of the embed layer. We cap the
+ * batch so a huge legacy store doesn't block boot; the remainder is picked up on
+ * subsequent boots.
+ *
+ * Returns the number of entities embedded in this pass.
+ */
+export async function backfillEntityEmbeddings(db: Database, maxBatch = 500): Promise<number> {
+  if (!vectorEnabled) return 0;
+  let pending: Array<{ id: string; name: string; summary: string | null; entity_type: string }>;
+  try {
+    pending = db
+      .prepare(
+        `SELECT e.id, e.name, e.summary, e.entity_type
+         FROM entities e
+         LEFT JOIN embeddings em ON em.content_id = e.id
+         WHERE em.content_id IS NULL
+         LIMIT ?`
+      )
+      .all(maxBatch) as Array<{ id: string; name: string; summary: string | null; entity_type: string }>;
+  } catch (err) {
+    logger.warn(`[vector] entity backfill scan failed: ${err instanceof Error ? err.message : String(err)}`);
+    return 0;
+  }
+  if (pending.length === 0) return 0;
+
+  const vecs = await prepareEmbeddingBatch(
+    pending.map((e) => entityEmbedText(e.name, e.summary, e.entity_type))
+  );
+
+  let written = 0;
+  try {
+    const tx = db.transaction(() => {
+      for (let i = 0; i < pending.length; i++) {
+        const vec = vecs[i];
+        if (!vec) continue;
+        writeEmbeddingSync(db, pending[i]!.id, 'entity', vec);
+        written++;
+      }
+    });
+    tx();
+  } catch (err) {
+    logger.warn(`[vector] entity backfill write failed: ${err instanceof Error ? err.message : String(err)}`);
+    return 0;
+  }
+  if (written > 0) logger.info(`[vector] backfilled ${written} entity embedding(s)`);
+  return written;
 }
 
 /**

--- a/src/server.ts
+++ b/src/server.ts
@@ -96,9 +96,23 @@ async function main(): Promise<void> {
 
   // Bootstrap the DB early so any schema errors surface before we announce ready.
   try {
-    getDb();
+    const db = getDb();
     logger.info('Database ready');
     process.stderr.write('[local-memory] database ready\n');
+    // v2.3.0 entity-embedding backfill: existing DBs created before entities
+    // were embeddable have entity rows with no vector, so vector/hybrid search
+    // over entities misses them. Run a one-shot, idempotent, best-effort
+    // backfill at boot — it no-ops on a fully-backfilled DB and never blocks
+    // startup (a failure just leaves rows FTS-only, retried next boot).
+    try {
+      const { isVectorEnabled, backfillEntityEmbeddings } = await import('./db/vector.js');
+      if (isVectorEnabled()) {
+        const n = await backfillEntityEmbeddings(db);
+        if (n > 0) process.stderr.write(`[local-memory] backfilled ${n} entity embedding(s)\n`);
+      }
+    } catch (err) {
+      logger.warn(`[local-memory] entity embedding backfill skipped: ${err instanceof Error ? err.message : String(err)}`);
+    }
   } catch (err) {
     logger.logError('Database init failed', err);
     process.stderr.write('[local-memory] database init failed: ' + (err instanceof Error ? err.stack ?? err.message : String(err)) + '\n');

--- a/src/server.ts
+++ b/src/server.ts
@@ -24,7 +24,7 @@ import { closeDb, getDb } from './db/client.js';
 import { getHandler, toMcpToolList, TOOLS } from './tools/registry.js';
 
 const SERVER_NAME = 'local-memory-mcp';
-const SERVER_VERSION = '2.2.0';
+const SERVER_VERSION = '2.3.0';
 
 const INSTRUCTIONS = `Local Memory — Persistent memory for your AI assistant.
 

--- a/src/tools/contradictions-cap.test.ts
+++ b/src/tools/contradictions-cap.test.ts
@@ -1,0 +1,148 @@
+/**
+ * Tests for the v2.3.0 per-entity observation cap on the contradiction scanner.
+ *
+ * The intra-entity self-join is O(N^2): one entity with thousands of
+ * observations is a quadratic cliff (millions of vec_distance_cosine calls).
+ * v2.3.0 caps the candidate set to `maxObservationsPerEntity` (default 200) of
+ * the freshest live+embedded observations per entity via a windowed CTE before
+ * the join. These tests prove the cap is honoured and that it keeps the
+ * freshest observations.
+ *
+ * Requires sqlite-vec. No-ops on platforms without it. Runs under
+ * MEMORY_EMBED_MOCK=1.
+ */
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { mkdtempSync, rmSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+
+let tmp = '';
+beforeEach(() => {
+  tmp = mkdtempSync(join(tmpdir(), 'local-memory-cap-'));
+  process.env.MEMORY_DB_PATH = join(tmp, 'test.sqlite');
+});
+afterEach(async () => {
+  const { closeDb } = await import('../db/client.js');
+  closeDb();
+  delete process.env.MEMORY_DB_PATH;
+  rmSync(tmp, { recursive: true, force: true });
+});
+
+describe('memory_contradictions — per-entity observation cap', () => {
+  it('only the freshest `maxObservationsPerEntity` observations enter the self-join', async () => {
+    const { entityCreate, entityObserve } = await import('./entity.js');
+    const { contradictions } = await import('./contradictions.js');
+    const { getDb } = await import('../db/client.js');
+    const { isVectorEnabled } = await import('../db/vector.js');
+    if (!isVectorEnabled()) return;
+
+    const created = entityCreate({ name: 'CapEntity', entityType: 'concept' });
+    if (!created.success) throw new Error('setup failed');
+    const eid = (created.data as { id: string }).id;
+
+    // Six observations forming three negation pairs. Give each a distinct
+    // valid_from so "freshest" is deterministic (rapid inserts share the
+    // same second otherwise).
+    const ids: string[] = [];
+    for (let i = 0; i < 6; i++) {
+      const o = await entityObserve({ entityId: eid, content: `signal ${Math.floor(i / 2)} is ${i % 2 === 0 ? '' : 'not '}on` });
+      if (!o.success) throw new Error('observe failed');
+      ids.push((o.data as { observationId: string }).observationId);
+    }
+    const db = getDb();
+    // valid_from increasing with index → index 4 & 5 are the two freshest.
+    for (let i = 0; i < 6; i++) {
+      db.prepare('UPDATE entity_observations SET valid_from = ? WHERE id = ?').run(
+        `2026-01-0${i + 1} 00:00:00`,
+        ids[i]
+      );
+    }
+
+    // Cap at 2 → only ids[4] + ids[5] survive into the join. They form one
+    // negation pair ("signal 2 is on" / "signal 2 is not on"), so at most one
+    // pair can come back, and only those two observation ids may appear.
+    const r = contradictions({ entityId: eid, minCosine: 0.4, maxObservationsPerEntity: 2 });
+    expect(r.success).toBe(true);
+    if (r.success) {
+      const d = r.data as {
+        pairs: Array<{ older: { id: string }; newer: { id: string } }>;
+        thresholds: { maxObservationsPerEntity: number };
+      };
+      expect(d.thresholds.maxObservationsPerEntity).toBe(2);
+      const seen = new Set<string>();
+      for (const p of d.pairs) {
+        seen.add(p.older.id);
+        seen.add(p.newer.id);
+      }
+      // Every referenced observation must be one of the two freshest.
+      const fresh = new Set([ids[4], ids[5]]);
+      for (const obsId of seen) {
+        expect(fresh.has(obsId)).toBe(true);
+      }
+      // At most one pair is possible from two observations.
+      expect(d.pairs.length).toBeLessThanOrEqual(1);
+    }
+  });
+
+  it('raising the cap surfaces older pairs that a low cap hides', async () => {
+    const { entityCreate, entityObserve } = await import('./entity.js');
+    const { contradictions } = await import('./contradictions.js');
+    const { getDb } = await import('../db/client.js');
+    const { isVectorEnabled } = await import('../db/vector.js');
+    if (!isVectorEnabled()) return;
+
+    const created = entityCreate({ name: 'CapWiden', entityType: 'concept' });
+    if (!created.success) throw new Error('setup failed');
+    const eid = (created.data as { id: string }).id;
+
+    const ids: string[] = [];
+    for (let i = 0; i < 6; i++) {
+      const o = await entityObserve({ entityId: eid, content: `flag ${Math.floor(i / 2)} is ${i % 2 === 0 ? '' : 'not '}set` });
+      if (!o.success) throw new Error('observe failed');
+      ids.push((o.data as { observationId: string }).observationId);
+    }
+    const db = getDb();
+    for (let i = 0; i < 6; i++) {
+      db.prepare('UPDATE entity_observations SET valid_from = ? WHERE id = ?').run(
+        `2026-02-0${i + 1} 00:00:00`,
+        ids[i]
+      );
+    }
+
+    const capped = contradictions({ entityId: eid, minCosine: 0.4, maxObservationsPerEntity: 2 });
+    const wide = contradictions({ entityId: eid, minCosine: 0.4, maxObservationsPerEntity: 200 });
+    expect(capped.success && wide.success).toBe(true);
+    if (capped.success && wide.success) {
+      const c = capped.data as { pairs: unknown[] };
+      const w = wide.data as { pairs: unknown[] };
+      // Three negation pairs exist; the low cap sees at most one, the wide cap
+      // sees more of them.
+      expect(w.pairs.length).toBeGreaterThan(c.pairs.length);
+    }
+  });
+
+  it('defaults the cap to 200 and reports it in thresholds', async () => {
+    const { entityCreate, entityObserve } = await import('./entity.js');
+    const { contradictions } = await import('./contradictions.js');
+    const { isVectorEnabled } = await import('../db/vector.js');
+    if (!isVectorEnabled()) return;
+
+    const created = entityCreate({ name: 'CapDefault', entityType: 'concept' });
+    if (!created.success) throw new Error('setup failed');
+    const eid = (created.data as { id: string }).id;
+    await entityObserve({ entityId: eid, content: 'thing is fine' });
+
+    const r = contradictions({ entityId: eid });
+    if (r.success) {
+      const d = r.data as { thresholds: { maxObservationsPerEntity: number } };
+      expect(d.thresholds.maxObservationsPerEntity).toBe(200);
+    }
+  });
+
+  it('rejects a cap below 2 (a pair needs two observations)', async () => {
+    const { contradictionsSchema } = await import('./contradictions.js');
+    expect(contradictionsSchema.safeParse({ maxObservationsPerEntity: 1 }).success).toBe(false);
+    expect(contradictionsSchema.safeParse({ maxObservationsPerEntity: 2 }).success).toBe(true);
+    expect(contradictionsSchema.safeParse({ maxObservationsPerEntity: 2001 }).success).toBe(false);
+  });
+});

--- a/src/tools/contradictions.ts
+++ b/src/tools/contradictions.ts
@@ -26,6 +26,13 @@
  * pairs even for power users with thousands of observations spread across
  * dozens of entities.
  *
+ * v2.3.0 perf cap: per-entity N is hard-capped by `maxObservationsPerEntity`
+ * (default 200) via a windowed CTE that keeps only the freshest live+embedded
+ * observations per entity before the self-join. This enforces the bound the
+ * earlier docstring only *hoped* for — a single entity with thousands of
+ * observations is now a fixed worst case (200·199/2 ≈ 20k cosine calls), not a
+ * quadratic cliff.
+ *
  * Output schema:
  *   - `pairs`: list of contradiction candidates, each with the older +
  *     newer observation, the cosine similarity, and the reasons flagged.
@@ -68,6 +75,11 @@ export const contradictionsSchema = z.object({
   minCosine: z.number().min(0).max(1).optional(),
   minConfidenceDrift: z.number().min(0).max(1).optional(),
   limit: z.number().int().min(1).max(200).optional(),
+  // P3.2 perf cap (v2.3.0): hard ceiling on how many of each entity's most-
+  // recent live observations enter the O(N^2) self-join. The docstring warned
+  // about the quadratic cliff; this enforces it. One entity with thousands of
+  // observations would otherwise produce millions of vec_distance_cosine calls.
+  maxObservationsPerEntity: z.number().int().min(2).max(2000).optional(),
 });
 
 type ContradictionRow = {
@@ -105,6 +117,14 @@ export function contradictions(input: z.infer<typeof contradictionsSchema>): Too
   const minCosine = input.minCosine ?? 0.75;
   const minConfDrift = input.minConfidenceDrift ?? 0.2;
   const limit = input.limit ?? 20;
+  // Default cap of 200 most-recent live observations per entity. The pair count
+  // for one entity is then bounded by 200*199/2 ≈ 20k vec_distance_cosine calls
+  // regardless of how many observations it actually has — turning the quadratic
+  // cliff into a fixed worst case. Power users who genuinely need a wider window
+  // can raise it (schema max 2000). Observations beyond the cap are the OLDEST
+  // ones (we keep the freshest by valid_from), which are also the least likely
+  // to be the "current" side of a live contradiction.
+  const maxObsPerEntity = input.maxObservationsPerEntity ?? 200;
 
   // Resolve scope. Order of precedence: entityId > entityName + entityType >
   // global scan. If a lookup misses we return an explicit NOT_FOUND so the
@@ -148,8 +168,35 @@ export function contradictions(input: z.infer<typeof contradictionsSchema>): Too
   // surface first. Ties broken by from_a DESC so newer pairs win.
   const overFetch = Math.min(limit * 5, 500);
 
-  const scopeFilter = entityScopeId ? 'AND a.entity_id = ?' : '';
+  // P3.2 perf cap (v2.3.0): a windowed CTE keeps only the `maxObsPerEntity`
+  // freshest LIVE+EMBEDDED observations per entity BEFORE the self-join. The
+  // embeddings JOIN is inside the CTE so only observations that can actually be
+  // compared count toward the cap (legacy obs without a vector were already
+  // dropped by the join, now they don't waste a cap slot either). The self-join
+  // then runs over this bounded set, so the pair count for any single entity is
+  // <= maxObsPerEntity*(maxObsPerEntity-1)/2 no matter how many observations it
+  // has accumulated. Ordering inside the partition is valid_from DESC, id DESC
+  // so the kept rows are deterministic and the freshest.
+  const scopeFilter = entityScopeId ? 'WHERE o.entity_id = ?' : '';
   const sql = `
+    WITH live_obs AS (
+      SELECT o.id,
+             o.entity_id,
+             o.content,
+             o.confidence,
+             o.valid_from,
+             em.embedding AS embedding,
+             ROW_NUMBER() OVER (
+               PARTITION BY o.entity_id
+               ORDER BY datetime(o.valid_from) DESC, o.id DESC
+             ) AS rn
+      FROM entity_observations o
+      JOIN embeddings em ON em.content_id = o.id
+      ${scopeFilter ? scopeFilter + ' AND o.valid_to IS NULL' : 'WHERE o.valid_to IS NULL'}
+    ),
+    capped AS (
+      SELECT * FROM live_obs WHERE rn <= ?
+    )
     SELECT *
     FROM (
       SELECT a.entity_id AS entity_id,
@@ -157,22 +204,17 @@ export function contradictions(input: z.infer<typeof contradictionsSchema>): Too
              e.entity_type AS entity_type,
              a.id AS id_a,
              b.id AS id_b,
-             (1.0 - vec_distance_cosine(ea.embedding, eb.embedding)) AS cosine_sim,
+             (1.0 - vec_distance_cosine(a.embedding, b.embedding)) AS cosine_sim,
              a.content AS content_a,
              b.content AS content_b,
              a.confidence AS conf_a,
              b.confidence AS conf_b,
              a.valid_from AS from_a,
              b.valid_from AS from_b
-      FROM entity_observations a
-      JOIN entity_observations b
+      FROM capped a
+      JOIN capped b
         ON b.entity_id = a.entity_id AND b.id < a.id
-      JOIN embeddings ea ON ea.content_id = a.id
-      JOIN embeddings eb ON eb.content_id = b.id
       JOIN entities e ON e.id = a.entity_id
-      WHERE a.valid_to IS NULL
-        AND b.valid_to IS NULL
-        ${scopeFilter}
     ) AS pairs
     WHERE cosine_sim >= ?
     ORDER BY cosine_sim DESC, from_a DESC
@@ -181,6 +223,7 @@ export function contradictions(input: z.infer<typeof contradictionsSchema>): Too
 
   const args: unknown[] = [];
   if (entityScopeId) args.push(entityScopeId);
+  args.push(maxObsPerEntity);
   args.push(minCosine);
   args.push(overFetch);
 
@@ -253,6 +296,7 @@ export function contradictions(input: z.infer<typeof contradictionsSchema>): Too
       thresholds: {
         minCosine,
         minConfidenceDrift: minConfDrift,
+        maxObservationsPerEntity: maxObsPerEntity,
       },
     },
     message:

--- a/src/tools/critical-paths.test.ts
+++ b/src/tools/critical-paths.test.ts
@@ -1,0 +1,184 @@
+/**
+ * v2.3.0 critical-path tests requested in the quality pass. These target exact
+ * window boundaries and guard rails that the broader suites don't pin down:
+ *
+ *   - entity_open({asOf}) at the valid_to == asOf edge (half-open window).
+ *   - entity_open({asOf}) at the valid_from == asOf edge (inclusive lower).
+ *   - observationSupersede inverted-window guard (cutoff == valid_from).
+ *   - contradictions scope NOT_FOUND for a missing entityName.
+ *
+ * Where the existing suites already cover a behaviour, these add the *distinct
+ * boundary* case rather than duplicating. Runs under MEMORY_EMBED_MOCK=1.
+ */
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { mkdtempSync, rmSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+
+let tmp = '';
+beforeEach(() => {
+  tmp = mkdtempSync(join(tmpdir(), 'local-memory-crit-'));
+  process.env.MEMORY_DB_PATH = join(tmp, 'test.sqlite');
+});
+afterEach(async () => {
+  const { closeDb } = await import('../db/client.js');
+  closeDb();
+  delete process.env.MEMORY_DB_PATH;
+  rmSync(tmp, { recursive: true, force: true });
+});
+
+describe('entity_open({asOf}) — window boundary edges', () => {
+  it('excludes an observation whose valid_to EXACTLY equals asOf (half-open window)', async () => {
+    // The query is valid_from <= asOf AND (valid_to IS NULL OR valid_to > asOf).
+    // At asOf == valid_to the fact has just stopped being true, so it must NOT
+    // appear — the window is [valid_from, valid_to).
+    const { entityCreate, entityObserve, entityOpen } = await import('./entity.js');
+    const { getDb } = await import('../db/client.js');
+
+    const e = entityCreate({ name: 'Boundary', entityType: 'concept' });
+    if (!e.success) throw new Error('setup failed');
+    const eid = (e.data as { id: string }).id;
+    const obs = await entityObserve({ entityId: eid, content: 'retired exactly at the cutoff' });
+    if (!obs.success) throw new Error('observe failed');
+    const oid = (obs.data as { observationId: string }).observationId;
+
+    // Window: valid_from 2026-01-01, valid_to 2026-03-01.
+    getDb()
+      .prepare('UPDATE entity_observations SET valid_from = ?, valid_to = ? WHERE id = ?')
+      .run('2026-01-01 00:00:00', '2026-03-01 00:00:00', oid);
+
+    // asOf == valid_to → excluded.
+    const at = entityOpen({ id: eid, asOf: '2026-03-01 00:00:00' });
+    expect(at.success).toBe(true);
+    if (at.success) {
+      const d = at.data as { observations: Array<{ id: string }> };
+      expect(d.observations.find((o) => o.id === oid)).toBeUndefined();
+    }
+
+    // One second before the cutoff → still live.
+    const justBefore = entityOpen({ id: eid, asOf: '2026-02-28 23:59:59' });
+    if (justBefore.success) {
+      const d = justBefore.data as { observations: Array<{ id: string }> };
+      expect(d.observations.some((o) => o.id === oid)).toBe(true);
+    }
+  });
+
+  it('includes an observation whose valid_from EXACTLY equals asOf (inclusive lower bound)', async () => {
+    const { entityCreate, entityObserve, entityOpen } = await import('./entity.js');
+    const { getDb } = await import('../db/client.js');
+
+    const e = entityCreate({ name: 'LowerEdge', entityType: 'concept' });
+    if (!e.success) throw new Error('setup failed');
+    const eid = (e.data as { id: string }).id;
+    const obs = await entityObserve({ entityId: eid, content: 'became true exactly at asOf' });
+    if (!obs.success) throw new Error('observe failed');
+    const oid = (obs.data as { observationId: string }).observationId;
+
+    getDb()
+      .prepare('UPDATE entity_observations SET valid_from = ?, valid_to = NULL WHERE id = ?')
+      .run('2026-04-15 00:00:00', oid);
+
+    // asOf == valid_from → included (valid_from <= asOf is inclusive).
+    const at = entityOpen({ id: eid, asOf: '2026-04-15 00:00:00' });
+    expect(at.success).toBe(true);
+    if (at.success) {
+      const d = at.data as { observations: Array<{ id: string }> };
+      expect(d.observations.some((o) => o.id === oid)).toBe(true);
+    }
+
+    // One second before valid_from → not yet true.
+    const before = entityOpen({ id: eid, asOf: '2026-04-14 23:59:59' });
+    if (before.success) {
+      const d = before.data as { observations: Array<{ id: string }> };
+      expect(d.observations.find((o) => o.id === oid)).toBeUndefined();
+    }
+  });
+});
+
+describe('observationSupersede — inverted-window guard', () => {
+  it('flags note when the explicit validTo equals the observation valid_from (degenerate window)', async () => {
+    // valid_to == valid_from means the window [from, to) is empty → the fact is
+    // never live at any instant. Allowed (retroactive retire) but must surface a
+    // note so it is not a silent surprise in a later asOf query.
+    const { entityCreate, entityObserve, observationSupersede } = await import('./entity.js');
+    const { getDb } = await import('../db/client.js');
+
+    const e = entityCreate({ name: 'Degenerate', entityType: 'concept' });
+    if (!e.success) throw new Error('setup failed');
+    const eid = (e.data as { id: string }).id;
+    const obs = await entityObserve({ entityId: eid, content: 'fact with a known start' });
+    if (!obs.success) throw new Error('observe failed');
+    const oid = (obs.data as { observationId: string }).observationId;
+
+    getDb()
+      .prepare('UPDATE entity_observations SET valid_from = ? WHERE id = ?')
+      .run('2026-05-01 00:00:00', oid);
+
+    // Cutoff EXACTLY at valid_from → inverted (empty) window → note expected.
+    const r = observationSupersede({ observationId: oid, validTo: '2026-05-01 00:00:00' });
+    expect(r.success).toBe(true);
+    if (r.success) {
+      const d = r.data as { action: string; validTo: string; note?: string };
+      expect(d.action).toBe('superseded');
+      expect(d.note).toBeDefined();
+      expect(d.note).toMatch(/will not be live/i);
+    }
+  });
+
+  it('does NOT flag the note for a normal forward window (cutoff after valid_from)', async () => {
+    const { entityCreate, entityObserve, observationSupersede } = await import('./entity.js');
+    const { getDb } = await import('../db/client.js');
+
+    const e = entityCreate({ name: 'Forward', entityType: 'concept' });
+    if (!e.success) throw new Error('setup failed');
+    const eid = (e.data as { id: string }).id;
+    const obs = await entityObserve({ entityId: eid, content: 'fact retired later, normally' });
+    if (!obs.success) throw new Error('observe failed');
+    const oid = (obs.data as { observationId: string }).observationId;
+
+    getDb()
+      .prepare('UPDATE entity_observations SET valid_from = ? WHERE id = ?')
+      .run('2026-05-01 00:00:00', oid);
+
+    const r = observationSupersede({ observationId: oid, validTo: '2026-06-01 00:00:00' });
+    if (r.success) {
+      const d = r.data as { note?: string };
+      expect(d.note).toBeUndefined();
+    }
+  });
+});
+
+describe('memory_contradictions — scope NOT_FOUND', () => {
+  it('returns NOT_FOUND when entityName resolves to no entity', async () => {
+    const { contradictions } = await import('./contradictions.js');
+    const { isVectorEnabled } = await import('../db/vector.js');
+    if (!isVectorEnabled()) return;
+
+    const r = contradictions({ entityName: 'NoSuchEntityName', entityType: 'concept' });
+    expect(r.success).toBe(false);
+    if (!r.success) {
+      expect(r.code).toBe('NOT_FOUND');
+    }
+  });
+
+  it('resolves an existing entityName+entityType to a scoped scan (scope echoes the id)', async () => {
+    const { entityCreate, entityObserve, contradictions } = await import('./entity.js').then(async (m) => ({
+      ...m,
+      contradictions: (await import('./contradictions.js')).contradictions,
+    }));
+    const { isVectorEnabled } = await import('../db/vector.js');
+    if (!isVectorEnabled()) return;
+
+    const created = entityCreate({ name: 'ScopedName', entityType: 'project' });
+    if (!created.success) throw new Error('setup failed');
+    const eid = (created.data as { id: string }).id;
+    await entityObserve({ entityId: eid, content: 'status is green' });
+
+    const r = contradictions({ entityName: 'ScopedName', entityType: 'project' });
+    expect(r.success).toBe(true);
+    if (r.success) {
+      const d = r.data as { scope: string };
+      expect(d.scope).toBe(`entity:${eid}`);
+    }
+  });
+});

--- a/src/tools/entity-embedding.test.ts
+++ b/src/tools/entity-embedding.test.ts
@@ -1,0 +1,173 @@
+/**
+ * Tests for the v2.3.0 entity-embedding bugfix.
+ *
+ * Before this fix, memory_search({mode:'vector', types:['entity']}) ALWAYS
+ * returned 0 because entities were never embedded, even though searchSchema
+ * advertised 'entity' in its types enum — a silent capability lie. These tests
+ * prove entities now embed on create/observe, that vector search surfaces them,
+ * that the write stays atomic (row + vector commit together), and that the boot
+ * backfill picks up legacy (pre-fix) entity rows.
+ *
+ * All require sqlite-vec (vector mode). They no-op on platforms without it.
+ * Runs under MEMORY_EMBED_MOCK=1.
+ */
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { mkdtempSync, rmSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+
+let tmp = '';
+beforeEach(() => {
+  tmp = mkdtempSync(join(tmpdir(), 'local-memory-entemb-'));
+  process.env.MEMORY_DB_PATH = join(tmp, 'test.sqlite');
+});
+afterEach(async () => {
+  const { closeDb } = await import('../db/client.js');
+  closeDb();
+  delete process.env.MEMORY_DB_PATH;
+  rmSync(tmp, { recursive: true, force: true });
+});
+
+describe('entity embedding — vector search over entities (the bugfix)', () => {
+  it('memory_search({mode:"vector", types:["entity"]}) returns an entity (was always 0)', async () => {
+    const { entityCreateEmbedded } = await import('./entity.js');
+    const { search } = await import('./search.js');
+    const { isVectorEnabled } = await import('../db/vector.js');
+    if (!isVectorEnabled()) return;
+
+    const created = await entityCreateEmbedded({
+      name: 'Helios',
+      entityType: 'project',
+      summary: 'solar telemetry platform',
+    });
+    expect(created.success).toBe(true);
+
+    const r = await search({ query: 'Helios', mode: 'vector', types: ['entity'] });
+    expect(r.success).toBe(true);
+    if (r.success) {
+      const d = r.data as { results: Array<{ id: string; type: string }>; count: number; mode: string };
+      expect(d.mode).toBe('vector');
+      expect(d.count).toBeGreaterThan(0);
+      expect(d.results.every((x) => x.type === 'entity')).toBe(true);
+      expect(d.results[0]?.id).toBe((created.data as { id: string }).id);
+    }
+  });
+
+  it('writes exactly one embeddings row of content_type=entity on create', async () => {
+    const { entityCreateEmbedded } = await import('./entity.js');
+    const { getDb } = await import('../db/client.js');
+    const { isVectorEnabled } = await import('../db/vector.js');
+    if (!isVectorEnabled()) return;
+
+    const created = await entityCreateEmbedded({ name: 'Vesta', entityType: 'tool' });
+    if (!created.success) throw new Error('setup failed');
+    const id = (created.data as { id: string }).id;
+
+    const cnt = (getDb()
+      .prepare("SELECT COUNT(*) AS c FROM embeddings WHERE content_id = ? AND content_type = 'entity'")
+      .get(id) as { c: number }).c;
+    expect(cnt).toBe(1);
+  });
+
+  it('entityObserve auto-creates an entity that is itself vector-searchable', async () => {
+    const { entityObserve } = await import('./entity.js');
+    const { getDb } = await import('../db/client.js');
+    const { isVectorEnabled } = await import('../db/vector.js');
+    if (!isVectorEnabled()) return;
+
+    const obs = await entityObserve({ entityName: 'Ceres', entityType: 'project', content: 'mapping survey' });
+    if (!obs.success) throw new Error('observe failed');
+    const entityId = (obs.data as { entityId: string }).entityId;
+
+    // The auto-created entity has its own embedding row.
+    const cnt = (getDb()
+      .prepare("SELECT COUNT(*) AS c FROM embeddings WHERE content_id = ? AND content_type = 'entity'")
+      .get(entityId) as { c: number }).c;
+    expect(cnt).toBe(1);
+  });
+
+  it('atomicity: a failed entity embedding write rolls back the entity row', async () => {
+    // Force the embedding INSERT to throw by writing a wrong-dim vector. The F4
+    // contract says writeEmbeddingSync lets the SqliteError propagate so the
+    // enclosing transaction rolls back the entity row INSERT too — no orphan.
+    // We exercise the shared internal path via entityCreateEmbedded but inject
+    // the failure by monkeypatching the embed pipeline to return a bad vector.
+    const embedMod = await import('../lib/embed.js');
+    const { getDb } = await import('../db/client.js');
+    const { isVectorEnabled } = await import('../db/vector.js');
+    if (!isVectorEnabled()) return;
+
+    const { entityCreateInternalForTest } = await import('./entity.js');
+
+    // A 7-dim vector is the wrong length for the float[384] vec0 column → INSERT
+    // throws inside the transaction.
+    const badVec = new Float32Array(7);
+    badVec[0] = 1;
+
+    const before = (getDb().prepare('SELECT COUNT(*) AS c FROM entities').get() as { c: number }).c;
+    let threw = false;
+    try {
+      entityCreateInternalForTest({ name: 'Phobos', entityType: 'moon' }, badVec);
+    } catch {
+      threw = true;
+    }
+    expect(threw).toBe(true);
+    const after = (getDb().prepare('SELECT COUNT(*) AS c FROM entities').get() as { c: number }).c;
+    // Row count unchanged → the entity INSERT rolled back with the bad embedding.
+    expect(after).toBe(before);
+    // And no entity named Phobos exists.
+    const ph = getDb().prepare('SELECT id FROM entities WHERE name = ?').get('Phobos');
+    expect(ph).toBeUndefined();
+    void embedMod; // imported for parity with sibling tests; not otherwise used.
+  });
+
+  it('refreshes the entity embedding when an existing entity gets a new summary', async () => {
+    const { entityCreateEmbedded } = await import('./entity.js');
+    const { search } = await import('./search.js');
+    const { isVectorEnabled } = await import('../db/vector.js');
+    if (!isVectorEnabled()) return;
+
+    // Create without summary, then re-create with a distinctive summary token.
+    const first = await entityCreateEmbedded({ name: 'Pallas', entityType: 'concept' });
+    if (!first.success) throw new Error('setup failed');
+    await entityCreateEmbedded({ name: 'Pallas', entityType: 'concept', summary: 'cryptographic ratchet design' });
+
+    // The summary token now participates in the entity vector.
+    const r = await search({ query: 'cryptographic ratchet', mode: 'vector', types: ['entity'] });
+    if (r.success) {
+      const d = r.data as { results: Array<{ id: string }>; count: number };
+      expect(d.count).toBeGreaterThan(0);
+      expect(d.results.some((x) => x.id === (first.data as { id: string }).id)).toBe(true);
+    }
+  });
+
+  it('backfillEntityEmbeddings embeds legacy entity rows created without a vector', async () => {
+    const { entityCreate } = await import('./entity.js');
+    const { backfillEntityEmbeddings, isVectorEnabled } = await import('../db/vector.js');
+    const { getDb } = await import('../db/client.js');
+    if (!isVectorEnabled()) return;
+
+    // The SYNC entityCreate writes the row but no embedding — exactly the
+    // pre-v2.3.0 legacy shape.
+    const created = entityCreate({ name: 'Juno', entityType: 'project', summary: 'asteroid orbiter' });
+    if (!created.success) throw new Error('setup failed');
+    const id = (created.data as { id: string }).id;
+
+    const before = (getDb()
+      .prepare("SELECT COUNT(*) AS c FROM embeddings WHERE content_id = ?")
+      .get(id) as { c: number }).c;
+    expect(before).toBe(0);
+
+    const n = await backfillEntityEmbeddings(getDb());
+    expect(n).toBeGreaterThanOrEqual(1);
+
+    const after = (getDb()
+      .prepare("SELECT COUNT(*) AS c FROM embeddings WHERE content_id = ? AND content_type = 'entity'")
+      .get(id) as { c: number }).c;
+    expect(after).toBe(1);
+
+    // A second backfill is a no-op (idempotent) — the row already has a vector.
+    const n2 = await backfillEntityEmbeddings(getDb());
+    expect(n2).toBe(0);
+  });
+});

--- a/src/tools/entity.ts
+++ b/src/tools/entity.ts
@@ -12,7 +12,7 @@
  */
 import { z } from 'zod';
 import { getDb, newId, nowIso, escapeFtsQuery } from '../db/client.js';
-import { prepareEmbedding, writeEmbeddingSync, deleteEmbeddings } from '../db/vector.js';
+import { prepareEmbedding, writeEmbeddingSync, deleteEmbeddings, entityEmbedText } from '../db/vector.js';
 import type { ToolResult } from '../lib/types.js';
 
 // ─── entity_create ───────────────────────────────────
@@ -24,7 +24,21 @@ export const entityCreateSchema = z.object({
   confidence: z.number().min(0).max(1).optional(),
 });
 
-export function entityCreate(input: z.infer<typeof entityCreateSchema>): ToolResult {
+// v2.3.0: entities are now embedded (name + summary + type) so vector / hybrid
+// search over `types: ['entity']` actually returns them. The write is split so
+// the sync row-insert stays available for callers that can't await
+// (entityCreateInternal) while the public MCP path embeds atomically.
+//
+// `vec` is the precomputed entity embedding (or null when vec is off / the
+// caller chose not to embed). When supplied it is written in the SAME
+// transaction as the row INSERT — the F4 atomic pattern shared with
+// learn/decide/observe: row + vector commit together or roll back together.
+// On the "already exists + new summary" path we refresh the embedding too,
+// because the summary is part of the embedded surface.
+function entityCreateInternal(
+  input: z.infer<typeof entityCreateSchema>,
+  vec: Float32Array | null,
+): ToolResult {
   const db = getDb();
 
   // Upsert: if name+type already exists, return existing
@@ -34,11 +48,19 @@ export function entityCreate(input: z.infer<typeof entityCreateSchema>): ToolRes
 
   if (existing) {
     if (input.summary) {
-      db.prepare('UPDATE entities SET summary = ?, updated_at = ? WHERE id = ?').run(
-        input.summary,
-        nowIso(),
-        existing.id
-      );
+      const tx = db.transaction(() => {
+        db.prepare('UPDATE entities SET summary = ?, updated_at = ? WHERE id = ?').run(
+          input.summary,
+          nowIso(),
+          existing.id
+        );
+        // Summary changed → the embedded surface changed. Refresh atomically.
+        // vec is null when the caller didn't pre-embed (sync entityCreate) — in
+        // that case writeEmbeddingSync no-ops and the boot backfill / next
+        // observe refreshes it.
+        writeEmbeddingSync(db, existing.id, 'entity', vec);
+      });
+      tx();
     }
     return {
       success: true,
@@ -48,16 +70,56 @@ export function entityCreate(input: z.infer<typeof entityCreateSchema>): ToolRes
   }
 
   const id = newId();
-  db.prepare(
-    `INSERT INTO entities (id, name, entity_type, summary, confidence)
-     VALUES (?, ?, ?, ?, ?)`
-  ).run(id, input.name, input.entityType, input.summary ?? null, input.confidence ?? 0.7);
+  const tx = db.transaction(() => {
+    db.prepare(
+      `INSERT INTO entities (id, name, entity_type, summary, confidence)
+       VALUES (?, ?, ?, ?, ?)`
+    ).run(id, input.name, input.entityType, input.summary ?? null, input.confidence ?? 0.7);
+    writeEmbeddingSync(db, id, 'entity', vec);
+  });
+  tx();
 
   return {
     success: true,
     data: { id, action: 'created' },
     message: `Entity "${input.name}" (${input.entityType}) angelegt.`,
   };
+}
+
+/**
+ * Synchronous entity create — writes the row (and FTS5 trigger) but does NOT
+ * embed, because embedding is async. The boot backfill + the observe path keep
+ * such rows reachable via vector search eventually. Kept for callers that need
+ * a synchronous result (and the existing test surface that calls it sync).
+ */
+export function entityCreate(input: z.infer<typeof entityCreateSchema>): ToolResult {
+  return entityCreateInternal(input, null);
+}
+
+/**
+ * Async entity create — the canonical MCP write path (used by the registry and
+ * by entityObserve's auto-create). Computes the entity embedding outside the
+ * transaction, then commits row + vector atomically. Falls back to the row-only
+ * write when vec is unavailable (extension off, embed failure). Same observable
+ * result shape as the sync entityCreate.
+ */
+export async function entityCreateEmbedded(input: z.infer<typeof entityCreateSchema>): Promise<ToolResult> {
+  const vec = await prepareEmbedding(entityEmbedText(input.name, input.summary ?? null, input.entityType));
+  return entityCreateInternal(input, vec);
+}
+
+/**
+ * Test-only seam: invoke the internal create-with-precomputed-vector path
+ * directly. Lets the atomicity test inject a deliberately-malformed vector to
+ * prove the row INSERT rolls back when the embedding write throws. Not part of
+ * the public tool surface — production callers use entityCreate /
+ * entityCreateEmbedded.
+ */
+export function entityCreateInternalForTest(
+  input: z.infer<typeof entityCreateSchema>,
+  vec: Float32Array | null,
+): ToolResult {
+  return entityCreateInternal(input, vec);
 }
 
 // ─── entity_observe ──────────────────────────────────
@@ -84,7 +146,10 @@ export async function entityObserve(input: z.infer<typeof entityObserveSchema>):
         code: 'MISSING_ENTITY_REF',
       };
     }
-    const created = entityCreate({
+    // Use the embedded create so an auto-created entity is vector-searchable
+    // too (entityObserve is already async). The observation gets its own
+    // embedding below; this embeds the entity name+type surface.
+    const created = await entityCreateEmbedded({
       name: input.entityName,
       entityType: input.entityType,
     });

--- a/src/tools/learn.ts
+++ b/src/tools/learn.ts
@@ -458,10 +458,38 @@ export async function learnBulk(input: z.infer<typeof learnBulkSchema>): Promise
 
 // ─── recall ──────────────────────────────────────────
 
+// recall is the quick, FTS5-only keyword path over LEARNINGS specifically
+// (memory_search is the hybrid, cross-type surface). v2.3.0 adds optional
+// project/tags scoping — both columns live directly on `learnings`, so the
+// filter is a cheap WHERE with no extra join. tags matches rows whose tags_json
+// array contains ANY of the given tags (json_each, exact membership).
 export const recallSchema = z.object({
   query: z.string().optional(),
   limit: z.number().int().min(1).max(100).optional(),
+  project: z.string().min(1).optional(),
+  tags: z.array(z.string().min(1)).min(1).optional(),
 });
+
+// Shared learnings-scope predicate for recall. `alias` is the table alias used
+// in the surrounding query ('l' in the FTS join, '' for the bare-table paths).
+function recallScopeClause(
+  input: z.infer<typeof recallSchema>,
+  alias: string
+): { clause: string; args: unknown[] } {
+  const col = alias ? `${alias}.` : '';
+  const parts: string[] = [];
+  const args: unknown[] = [];
+  if (input.project !== undefined) {
+    parts.push(`${col}project = ?`);
+    args.push(input.project);
+  }
+  if (input.tags && input.tags.length > 0) {
+    const ph = input.tags.map(() => '?').join(',');
+    parts.push(`EXISTS (SELECT 1 FROM json_each(${col}tags_json) WHERE value IN (${ph}))`);
+    args.push(...input.tags);
+  }
+  return { clause: parts.length > 0 ? `AND ${parts.join(' AND ')}` : '', args };
+}
 
 export function recall(input: z.infer<typeof recallSchema>): ToolResult {
   const db = getDb();
@@ -469,21 +497,24 @@ export function recall(input: z.infer<typeof recallSchema>): ToolResult {
 
   if (!input.query || input.query.trim().length === 0) {
     // No query → return most recent learnings
+    const scope = recallScopeClause(input, '');
     const rows = db
       .prepare(
         `SELECT id, date, category, content, project, confidence, memory_type
          FROM learnings
          WHERE archived = 0
+         ${scope.clause}
          ORDER BY date DESC
          LIMIT ?`
       )
-      .all(limit);
+      .all(...scope.args, limit);
     return { success: true, data: { results: rows, count: (rows as unknown[]).length } };
   }
 
   // FTS5 search
   try {
     const fts = escapeFtsQuery(input.query);
+    const scope = recallScopeClause(input, 'l');
     const rows = db
       .prepare(
         `SELECT l.id, l.date, l.category, l.content, l.project, l.confidence, l.memory_type,
@@ -492,22 +523,25 @@ export function recall(input: z.infer<typeof recallSchema>): ToolResult {
          JOIN learnings l ON l.id = search_fts.content_id
          WHERE search_fts MATCH ? AND search_fts.content_type = 'learning'
          AND l.archived = 0
+         ${scope.clause}
          ORDER BY rank
          LIMIT ?`
       )
-      .all(fts, limit);
+      .all(fts, ...scope.args, limit);
     return { success: true, data: { results: rows, count: (rows as unknown[]).length } };
   } catch {
     // Fallback to LIKE if FTS query parsing fails
+    const scope = recallScopeClause(input, '');
     const rows = db
       .prepare(
         `SELECT id, date, category, content, project, confidence, memory_type
          FROM learnings
          WHERE content LIKE ? AND archived = 0
+         ${scope.clause}
          ORDER BY date DESC
          LIMIT ?`
       )
-      .all(`%${input.query}%`, limit);
+      .all(`%${input.query}%`, ...scope.args, limit);
     return { success: true, data: { results: rows, count: (rows as unknown[]).length } };
   }
 }

--- a/src/tools/ranking.test.ts
+++ b/src/tools/ranking.test.ts
@@ -1,0 +1,221 @@
+/**
+ * Tests for the v2.3.0 recency / usage / importance ranking boost on the
+ * hybrid (RRF) search path.
+ *
+ * Strategy: seed two learnings with the SAME token shape for the query
+ * ("zenith alpha" / "zenith bravo"). For the query "zenith" both rankers score
+ * them identically (same BM25 term/length, and the mock cosine's zenith
+ * component is identical while the unique second token is orthogonal to the
+ * query), so the base RRF score is a perfect tie. Any difference in final order
+ * is therefore attributable to the boost alone — a clean, deterministic probe.
+ *
+ * These cases require sqlite-vec (the boost lives in the RRF fusion, only
+ * reached in hybrid mode). They no-op on platforms without vec, matching the
+ * existing hybrid tests. Runs under MEMORY_EMBED_MOCK=1.
+ */
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { mkdtempSync, rmSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+
+let tmp = '';
+beforeEach(() => {
+  tmp = mkdtempSync(join(tmpdir(), 'local-memory-ranking-'));
+  process.env.MEMORY_DB_PATH = join(tmp, 'test.sqlite');
+});
+afterEach(async () => {
+  const { closeDb } = await import('../db/client.js');
+  closeDb();
+  delete process.env.MEMORY_DB_PATH;
+  rmSync(tmp, { recursive: true, force: true });
+});
+
+describe('hybrid ranking boost (v2.3.0)', () => {
+  it('an important doc outranks an equally-relevant unimportant one', async () => {
+    const { learn } = await import('./learn.js');
+    const { search } = await import('./search.js');
+    const { getDb } = await import('../db/client.js');
+    const { isVectorEnabled } = await import('../db/vector.js');
+    if (!isVectorEnabled()) return;
+
+    const plain = await learn({ category: 'pattern', content: 'zenith alpha' });
+    const important = await learn({ category: 'pattern', content: 'zenith bravo' });
+    if (!plain.success || !important.success) throw new Error('setup failed');
+
+    // Make the second doc important; leave the first at NULL importance.
+    getDb()
+      .prepare('UPDATE learnings SET importance = 0.95 WHERE id = ?')
+      .run((important.data as { id: string }).id);
+
+    const r = await search({ query: 'zenith', mode: 'hybrid', limit: 5 });
+    expect(r.success).toBe(true);
+    if (r.success) {
+      const d = r.data as { results: Array<{ id: string; rank: number }>; mode: string };
+      expect(d.mode).toBe('hybrid');
+      expect(d.results.length).toBe(2);
+      // The important doc must come first, and carry a strictly higher score.
+      expect(d.results[0]?.id).toBe((important.data as { id: string }).id);
+      expect(d.results[0]!.rank).toBeGreaterThan(d.results[1]!.rank);
+    }
+  });
+
+  it('a recent doc outranks an equally-relevant stale one', async () => {
+    const { learn } = await import('./learn.js');
+    const { search } = await import('./search.js');
+    const { getDb } = await import('../db/client.js');
+    const { isVectorEnabled } = await import('../db/vector.js');
+    if (!isVectorEnabled()) return;
+
+    const stale = await learn({ category: 'pattern', content: 'zenith alpha' });
+    const recent = await learn({ category: 'pattern', content: 'zenith bravo' });
+    if (!stale.success || !recent.success) throw new Error('setup failed');
+
+    // Age the first doc by a year via its date; the second keeps "now".
+    getDb()
+      .prepare("UPDATE learnings SET date = '2025-01-01 00:00:00', last_used = NULL WHERE id = ?")
+      .run((stale.data as { id: string }).id);
+
+    const r = await search({ query: 'zenith', mode: 'hybrid', limit: 5 });
+    expect(r.success).toBe(true);
+    if (r.success) {
+      const d = r.data as { results: Array<{ id: string }> };
+      expect(d.results[0]?.id).toBe((recent.data as { id: string }).id);
+    }
+  });
+
+  it('a heavily-used doc outranks an equally-relevant unused one', async () => {
+    const { learn } = await import('./learn.js');
+    const { search } = await import('./search.js');
+    const { getDb } = await import('../db/client.js');
+    const { isVectorEnabled } = await import('../db/vector.js');
+    if (!isVectorEnabled()) return;
+
+    const cold = await learn({ category: 'pattern', content: 'zenith alpha' });
+    const hot = await learn({ category: 'pattern', content: 'zenith bravo' });
+    if (!cold.success || !hot.success) throw new Error('setup failed');
+
+    getDb()
+      .prepare('UPDATE learnings SET usage_count = 50 WHERE id = ?')
+      .run((hot.data as { id: string }).id);
+
+    const r = await search({ query: 'zenith', mode: 'hybrid', limit: 5 });
+    if (r.success) {
+      const d = r.data as { results: Array<{ id: string }> };
+      expect(d.results[0]?.id).toBe((hot.data as { id: string }).id);
+    }
+  });
+
+  it('preserves pure-relevance ordering when ranking signals are equal', async () => {
+    // Two docs, equal signals (both fresh, importance NULL, usage 0). The boost
+    // multiplier is identical for both, so their order is governed solely by the
+    // base RRF score — i.e. a true tie stays a tie and the boost introduces no
+    // bias. We assert their scores are equal (within float epsilon).
+    const { learn } = await import('./learn.js');
+    const { search } = await import('./search.js');
+    const { isVectorEnabled } = await import('../db/vector.js');
+    if (!isVectorEnabled()) return;
+
+    await learn({ category: 'pattern', content: 'zenith alpha' });
+    await learn({ category: 'pattern', content: 'zenith bravo' });
+
+    const r = await search({ query: 'zenith', mode: 'hybrid', limit: 5 });
+    if (r.success) {
+      const d = r.data as { results: Array<{ rank: number }> };
+      expect(d.results.length).toBe(2);
+      expect(Math.abs(d.results[0]!.rank - d.results[1]!.rank)).toBeLessThan(1e-9);
+    }
+  });
+
+  it('does not let recency override a clear textual-relevance gap (conservative bound)', async () => {
+    // One doc matches BOTH query tokens, the other only ONE and is brand new.
+    // The strong textual match must still win even though the weak one is the
+    // freshest — the boost decides ties, not clear winners.
+    const { learn } = await import('./learn.js');
+    const { search } = await import('./search.js');
+    const { getDb } = await import('../db/client.js');
+    const { isVectorEnabled } = await import('../db/vector.js');
+    if (!isVectorEnabled()) return;
+
+    const strong = await learn({ category: 'pattern', content: 'quantum entanglement protocol notes' });
+    const weak = await learn({ category: 'pattern', content: 'quantum breakfast cereal' });
+    if (!strong.success || !weak.success) throw new Error('setup failed');
+
+    // Make the weak match maximally recent + important; age the strong one.
+    getDb()
+      .prepare("UPDATE learnings SET importance = 1.0, usage_count = 100 WHERE id = ?")
+      .run((weak.data as { id: string }).id);
+    getDb()
+      .prepare("UPDATE learnings SET date = '2024-01-01 00:00:00' WHERE id = ?")
+      .run((strong.data as { id: string }).id);
+
+    const r = await search({ query: 'quantum entanglement protocol', mode: 'hybrid', limit: 5 });
+    if (r.success) {
+      const d = r.data as { results: Array<{ id: string }> };
+      // The two-token-plus match still ranks first despite the boost on the weak one.
+      expect(d.results[0]?.id).toBe((strong.data as { id: string }).id);
+    }
+  });
+
+  it('the ranking.* override (weights all 0) disables the boost', async () => {
+    // With the boost disabled, an important doc no longer jumps ahead of an
+    // equally-relevant one — the order collapses to the pure RRF tie.
+    const { learn } = await import('./learn.js');
+    const { search } = await import('./search.js');
+    const { getDb } = await import('../db/client.js');
+    const { isVectorEnabled } = await import('../db/vector.js');
+    if (!isVectorEnabled()) return;
+
+    const plain = await learn({ category: 'pattern', content: 'zenith alpha' });
+    const important = await learn({ category: 'pattern', content: 'zenith bravo' });
+    if (!plain.success || !important.success) throw new Error('setup failed');
+    getDb()
+      .prepare('UPDATE learnings SET importance = 0.99 WHERE id = ?')
+      .run((important.data as { id: string }).id);
+
+    const r = await search({
+      query: 'zenith',
+      mode: 'hybrid',
+      limit: 5,
+      ranking: { recencyWeight: 0, usageWeight: 0, importanceWeight: 0 },
+    });
+    if (r.success) {
+      const d = r.data as { results: Array<{ rank: number }> };
+      // Scores tie again because the boost is off.
+      expect(Math.abs(d.results[0]!.rank - d.results[1]!.rank)).toBeLessThan(1e-9);
+    }
+  });
+});
+
+describe('RRF fusion — both-ranker consensus beats single-ranker (v2.3.0 critical path)', () => {
+  it('a doc found by BOTH BM25 and cosine outranks one found by a single ranker', async () => {
+    // The defining property of RRF: a candidate that appears in two rankings
+    // accumulates two 1/(k+rank) contributions and should beat a candidate that
+    // only one ranker surfaced. We construct:
+    //   - consensus: contains the literal query tokens (BM25 hit) AND is
+    //     token-similar (cosine hit) → seen by both legs.
+    //   - vecOnly: shares NO literal query token (BM25 miss) but is token-near
+    //     enough for the mock cosine to surface it → seen by one leg only.
+    // The consensus row must rank above the single-ranker row.
+    const { learn } = await import('./learn.js');
+    const { search } = await import('./search.js');
+    const { isVectorEnabled } = await import('../db/vector.js');
+    if (!isVectorEnabled()) return;
+
+    const consensus = await learn({ category: 'pattern', content: 'meridian orbit calculation' });
+    const vecOnly = await learn({ category: 'pattern', content: 'orbit calculation telemetry' });
+    if (!consensus.success || !vecOnly.success) throw new Error('setup failed');
+
+    // Query contains "meridian" (only in consensus) plus shared tokens. BM25
+    // ranks consensus far higher (it has the rare token); cosine surfaces both.
+    const r = await search({ query: 'meridian orbit calculation', mode: 'hybrid', limit: 5 });
+    expect(r.success).toBe(true);
+    if (r.success) {
+      const d = r.data as { results: Array<{ id: string; rank: number }> };
+      const consensusId = (consensus.data as { id: string }).id;
+      const vecOnlyId = (vecOnly.data as { id: string }).id;
+      const rankOf = (id: string) => d.results.find((x) => x.id === id)?.rank ?? -Infinity;
+      expect(d.results[0]?.id).toBe(consensusId);
+      expect(rankOf(consensusId)).toBeGreaterThan(rankOf(vecOnlyId));
+    }
+  });
+});

--- a/src/tools/registry.ts
+++ b/src/tools/registry.ts
@@ -21,7 +21,7 @@ import {
 import { search, searchSchema } from './search.js';
 import { decide, decideSchema } from './decide.js';
 import {
-  entityCreate, entityCreateSchema,
+  entityCreateEmbedded, entityCreateSchema,
   entityObserve, entityObserveSchema,
   entitySearch, entitySearchSchema,
   entityOpen, entityOpenSchema,
@@ -74,7 +74,7 @@ export const TOOLS: ToolDef[] = [
   },
   {
     name: 'memory_recall',
-    description: 'Quick recall: keyword search on learnings, or omit query for most-recent.',
+    description: 'Quick FTS5 keyword recall over learnings only (no vector/hybrid — use memory_search for that). Optional project/tags scoping. Omit query for most-recent.',
     schema: recallSchema,
     handler: (input) => recall(input as z.infer<typeof recallSchema>),
   },
@@ -98,7 +98,7 @@ export const TOOLS: ToolDef[] = [
   },
   {
     name: 'memory_search',
-    description: 'Unified search across learnings, decisions, entities, and observations (FTS5 + bm25).',
+    description: 'Unified hybrid search across learnings, decisions, entities, and observations (FTS5 BM25 + vector cosine fused with RRF). mode: fts|vector|hybrid (default hybrid). Optional project/tags scoping.',
     schema: searchSchema,
     handler: (input) => search(input as z.infer<typeof searchSchema>),
   },
@@ -110,9 +110,9 @@ export const TOOLS: ToolDef[] = [
   },
   {
     name: 'memory_entity_create',
-    description: 'Create an entity explicitly (without an initial observation). Idempotent on name+entityType.',
+    description: 'Create an entity explicitly (without an initial observation). Idempotent on name+entityType. Embeds name+summary so vector/hybrid search over entities finds it.',
     schema: entityCreateSchema,
-    handler: (input) => entityCreate(input as z.infer<typeof entityCreateSchema>),
+    handler: (input) => entityCreateEmbedded(input as z.infer<typeof entityCreateSchema>),
   },
   {
     name: 'memory_entity_observe',
@@ -146,7 +146,7 @@ export const TOOLS: ToolDef[] = [
   },
   {
     name: 'memory_contradictions',
-    description: 'Scan observation pairs with high cosine similarity but disagreeing negation/confidence. LLM-free heuristic. Requires sqlite-vec.',
+    description: 'Scan observation pairs with high cosine similarity but disagreeing negation/confidence. LLM-free heuristic. Requires sqlite-vec. Per-entity observations are capped (maxObservationsPerEntity, default 200) to bound the O(N^2) self-join.',
     schema: contradictionsSchema,
     handler: (input) => contradictions(input as z.infer<typeof contradictionsSchema>),
   },

--- a/src/tools/scoping.test.ts
+++ b/src/tools/scoping.test.ts
@@ -1,0 +1,248 @@
+/**
+ * Tests for v2.3.0 project/tags scoping on memory_search and memory_recall.
+ *
+ * The two main retrieval tools previously had no way to scope to one project,
+ * even though insights/reflect accepted `project`. These tests prove:
+ *   - search scoped to a project returns only that project's rows.
+ *   - search scoped by tags returns only rows carrying one of the tags.
+ *   - recall (FTS-only) honours the same project/tags filters.
+ *   - the absent-filter behaviour is unchanged (regression guard).
+ *
+ * Runs under MEMORY_EMBED_MOCK=1 (set by `npm test`) so the embedding pipeline
+ * is deterministic. Scoping is applied in every mode; we exercise it through the
+ * default hybrid path and an explicit fts path.
+ */
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { mkdtempSync, rmSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+
+let tmp = '';
+beforeEach(() => {
+  tmp = mkdtempSync(join(tmpdir(), 'local-memory-scoping-'));
+  process.env.MEMORY_DB_PATH = join(tmp, 'test.sqlite');
+});
+afterEach(async () => {
+  const { closeDb } = await import('../db/client.js');
+  closeDb();
+  delete process.env.MEMORY_DB_PATH;
+  rmSync(tmp, { recursive: true, force: true });
+});
+
+describe('memory_search — project scoping', () => {
+  it('returns only rows from the requested project', async () => {
+    const { learn } = await import('./learn.js');
+    const { search } = await import('./search.js');
+    await learn({ category: 'pattern', content: 'kafka topic partition strategy', project: 'alpha' });
+    await learn({ category: 'pattern', content: 'kafka consumer group rebalancing', project: 'beta' });
+
+    const r = await search({ query: 'kafka', project: 'alpha' });
+    expect(r.success).toBe(true);
+    if (r.success) {
+      const d = r.data as { results: Array<{ body: string }>; count: number; project?: string };
+      expect(d.count).toBe(1);
+      expect(d.results[0]?.body).toContain('partition');
+      expect(d.project).toBe('alpha');
+    }
+  });
+
+  it('scopes decisions by project too', async () => {
+    const { decide } = await import('./decide.js');
+    const { search } = await import('./search.js');
+    await decide({ title: 'pinot for olap', decision: 'adopt', reasoning: 'fast', project: 'alpha' });
+    await decide({ title: 'pinot rollout plan', decision: 'phase it', reasoning: 'risk', project: 'beta' });
+
+    const r = await search({ query: 'pinot', project: 'beta', mode: 'fts' });
+    expect(r.success).toBe(true);
+    if (r.success) {
+      const d = r.data as { results: Array<{ title: string }> };
+      expect(d.results.length).toBe(1);
+      expect(d.results[0]?.title).toBe('pinot rollout plan');
+    }
+  });
+
+  it('excludes entity/observation rows when a project filter is active (they have no project)', async () => {
+    const { learn } = await import('./learn.js');
+    const { entityCreate } = await import('./entity.js');
+    const { search } = await import('./search.js');
+    await learn({ category: 'pattern', content: 'orion telemetry pipeline', project: 'alpha' });
+    entityCreate({ name: 'Orion', entityType: 'project', summary: 'orion telemetry' });
+
+    // Unscoped: both the learning and the entity match "orion".
+    const unscoped = await search({ query: 'orion', mode: 'fts' });
+    if (unscoped.success) {
+      const d = unscoped.data as { results: Array<{ type: string }> };
+      expect(d.results.some((x) => x.type === 'entity')).toBe(true);
+    }
+
+    // Scoped to alpha: only the learning survives — the entity has no project.
+    const scoped = await search({ query: 'orion', project: 'alpha', mode: 'fts' });
+    if (scoped.success) {
+      const d = scoped.data as { results: Array<{ type: string }> };
+      expect(d.results.length).toBeGreaterThan(0);
+      expect(d.results.every((x) => x.type === 'learning')).toBe(true);
+    }
+  });
+
+  it('returns an empty set for a project with no matching rows (not an error)', async () => {
+    const { learn } = await import('./learn.js');
+    const { search } = await import('./search.js');
+    await learn({ category: 'pattern', content: 'redis pub sub fanout', project: 'alpha' });
+    const r = await search({ query: 'redis', project: 'nonexistent' });
+    expect(r.success).toBe(true);
+    if (r.success) {
+      const d = r.data as { count: number };
+      expect(d.count).toBe(0);
+    }
+  });
+});
+
+describe('memory_search — tags scoping', () => {
+  it('returns only rows carrying one of the requested tags', async () => {
+    const { learn } = await import('./learn.js');
+    const { search } = await import('./search.js');
+    await learn({ category: 'pattern', content: 'grafana dashboard layout', tags: ['observability', 'ui'] });
+    await learn({ category: 'pattern', content: 'grafana alerting rules', tags: ['oncall'] });
+
+    const r = await search({ query: 'grafana', tags: ['observability'] });
+    expect(r.success).toBe(true);
+    if (r.success) {
+      const d = r.data as { results: Array<{ body: string }>; count: number; tags?: string[] };
+      expect(d.count).toBe(1);
+      expect(d.results[0]?.body).toContain('dashboard');
+      expect(d.tags).toEqual(['observability']);
+    }
+  });
+
+  it('matches ANY of multiple tags (OR semantics)', async () => {
+    const { learn } = await import('./learn.js');
+    const { search } = await import('./search.js');
+    await learn({ category: 'pattern', content: 'nebula one', tags: ['x'] });
+    await learn({ category: 'pattern', content: 'nebula two', tags: ['y'] });
+    await learn({ category: 'pattern', content: 'nebula three', tags: ['z'] });
+
+    const r = await search({ query: 'nebula', tags: ['x', 'y'], mode: 'fts' });
+    if (r.success) {
+      const d = r.data as { results: Array<{ body: string }>; count: number };
+      expect(d.count).toBe(2);
+      const bodies = d.results.map((x) => x.body).join(' ');
+      expect(bodies).toContain('one');
+      expect(bodies).toContain('two');
+      expect(bodies).not.toContain('three');
+    }
+  });
+
+  it('exact tag membership — a tag "ui" does not match a tag "build" (no substring collisions)', async () => {
+    const { learn } = await import('./learn.js');
+    const { search } = await import('./search.js');
+    await learn({ category: 'pattern', content: 'guidance one', tags: ['guide'] });
+    // "gui" must NOT match the stored "guide" tag — json_each is exact.
+    const r = await search({ query: 'guidance', tags: ['gui'], mode: 'fts' });
+    if (r.success) {
+      const d = r.data as { count: number };
+      expect(d.count).toBe(0);
+    }
+  });
+
+  it('combines project AND tags (both must hold)', async () => {
+    const { learn } = await import('./learn.js');
+    const { search } = await import('./search.js');
+    await learn({ category: 'pattern', content: 'saturn alpha tagged', project: 'alpha', tags: ['keep'] });
+    await learn({ category: 'pattern', content: 'saturn alpha untagged', project: 'alpha', tags: ['drop'] });
+    await learn({ category: 'pattern', content: 'saturn beta tagged', project: 'beta', tags: ['keep'] });
+
+    const r = await search({ query: 'saturn', project: 'alpha', tags: ['keep'], mode: 'fts' });
+    if (r.success) {
+      const d = r.data as { results: Array<{ body: string }>; count: number };
+      expect(d.count).toBe(1);
+      expect(d.results[0]?.body).toContain('alpha tagged');
+    }
+  });
+});
+
+describe('memory_search — absent filter = unchanged behaviour (regression guard)', () => {
+  it('returns all matching rows when neither project nor tags is passed', async () => {
+    const { learn } = await import('./learn.js');
+    const { search } = await import('./search.js');
+    await learn({ category: 'pattern', content: 'vega entry one', project: 'alpha' });
+    await learn({ category: 'pattern', content: 'vega entry two', project: 'beta' });
+    await learn({ category: 'pattern', content: 'vega entry three' });
+
+    const r = await search({ query: 'vega', mode: 'fts' });
+    if (r.success) {
+      const d = r.data as { count: number; project?: string; tags?: string[] };
+      expect(d.count).toBe(3);
+      // No echo of project/tags when not requested.
+      expect(d.project).toBeUndefined();
+      expect(d.tags).toBeUndefined();
+    }
+  });
+});
+
+describe('memory_recall — project/tags scoping (FTS-only)', () => {
+  it('scopes recall results by project', async () => {
+    const { learn, recall } = await import('./learn.js');
+    await learn({ category: 'pattern', content: 'lyra ingestion job', project: 'alpha' });
+    await learn({ category: 'pattern', content: 'lyra ingestion retry', project: 'beta' });
+
+    const r = recall({ query: 'lyra', project: 'alpha' });
+    expect(r.success).toBe(true);
+    if (r.success) {
+      const d = r.data as { results: Array<{ content: string; project: string }>; count: number };
+      expect(d.count).toBe(1);
+      expect(d.results[0]?.project).toBe('alpha');
+    }
+  });
+
+  it('scopes recall results by tags', async () => {
+    const { learn, recall } = await import('./learn.js');
+    await learn({ category: 'pattern', content: 'cetus deploy step', tags: ['ops'] });
+    await learn({ category: 'pattern', content: 'cetus deploy notes', tags: ['docs'] });
+
+    const r = recall({ query: 'cetus', tags: ['ops'] });
+    if (r.success) {
+      const d = r.data as { results: Array<{ content: string }>; count: number };
+      expect(d.count).toBe(1);
+      expect(d.results[0]?.content).toContain('step');
+    }
+  });
+
+  it('scopes the no-query most-recent path by project', async () => {
+    const { learn, recall } = await import('./learn.js');
+    await learn({ category: 'pattern', content: 'draco fact a', project: 'alpha' });
+    await learn({ category: 'pattern', content: 'draco fact b', project: 'beta' });
+
+    const r = recall({ project: 'beta' });
+    if (r.success) {
+      const d = r.data as { results: Array<{ project: string }>; count: number };
+      expect(d.count).toBe(1);
+      expect(d.results.every((x) => x.project === 'beta')).toBe(true);
+    }
+  });
+
+  it('absent filter returns all live learnings (regression guard)', async () => {
+    const { learn, recall } = await import('./learn.js');
+    await learn({ category: 'pattern', content: 'hydra one', project: 'alpha' });
+    await learn({ category: 'pattern', content: 'hydra two' });
+    const r = recall({ query: 'hydra' });
+    if (r.success) {
+      const d = r.data as { count: number };
+      expect(d.count).toBe(2);
+    }
+  });
+});
+
+describe('schema — project/tags validation', () => {
+  it('search schema accepts project + tags', async () => {
+    const { searchSchema } = await import('./search.js');
+    expect(searchSchema.safeParse({ query: 'x', project: 'p', tags: ['a', 'b'] }).success).toBe(true);
+  });
+  it('search schema rejects an empty tags array', async () => {
+    const { searchSchema } = await import('./search.js');
+    expect(searchSchema.safeParse({ query: 'x', tags: [] }).success).toBe(false);
+  });
+  it('recall schema accepts project + tags', async () => {
+    const { recallSchema } = await import('./learn.js');
+    expect(recallSchema.safeParse({ query: 'x', project: 'p', tags: ['a'] }).success).toBe(true);
+  });
+});

--- a/src/tools/search.ts
+++ b/src/tools/search.ts
@@ -18,6 +18,15 @@
  * derivable from the query. If either fails (extension missing, model
  * blocked, mock-disabled in tests) we silently fall back to FTS5 — never
  * surface the error to the client, just degrade gracefully.
+ *
+ * v2.3.0 adds two orthogonal capabilities:
+ *   - project/tags scoping (cheap WHERE on the source tables) so a
+ *     multi-project user can scope retrieval the same way insights/reflect do.
+ *   - a conservative recency + usage + importance ranking boost applied
+ *     post-fusion in hybrid mode (see rankingMultiplier). It re-orders near
+ *     textual ties toward fresh/important rows but is tuned so it cannot
+ *     override a clear textual relevance gap, and is a no-op (identity
+ *     multiplier) when the ranking signals are equal.
  */
 import { z } from 'zod';
 import { getDb, escapeFtsQuery } from '../db/client.js';
@@ -25,11 +34,67 @@ import { isVectorEnabled } from '../db/vector.js';
 import { embedQuery, EMBEDDING_DIM } from '../lib/embed.js';
 import type { ToolResult } from '../lib/types.js';
 
+// ─── Ranking-boost tunables ───────────────────────────
+// Conservative defaults: the maximum combined boost a row can earn is
+// recencyWeight + usageWeight + importanceWeight = 0.40, i.e. +40% on its RRF
+// score. RRF gaps between adjacent ranks near the top are small relative to the
+// score itself, so a row that is a clear textual winner on both rankers keeps
+// its lead; the boost only decides near-ties. All three are independently
+// tunable per-call via the `ranking` input or globally via env. Set them to 0
+// to disable the boost entirely.
+const DEFAULT_RANKING = {
+  recencyWeight: 0.15,
+  usageWeight: 0.1,
+  importanceWeight: 0.15,
+  // Exponential decay half-life in days for the recency term. A row touched
+  // `halfLifeDays` ago contributes half of recencyWeight.
+  halfLifeDays: 30,
+} as const;
+
+function envNum(name: string, fallback: number): number {
+  const raw = process.env[name];
+  if (raw === undefined) return fallback;
+  const n = Number(raw);
+  return Number.isFinite(n) ? n : fallback;
+}
+
+interface RankingOpts {
+  recencyWeight: number;
+  usageWeight: number;
+  importanceWeight: number;
+  halfLifeDays: number;
+}
+
+function resolveRanking(input?: Partial<RankingOpts>): RankingOpts {
+  return {
+    recencyWeight: input?.recencyWeight ?? envNum('MEMORY_RANK_RECENCY_WEIGHT', DEFAULT_RANKING.recencyWeight),
+    usageWeight: input?.usageWeight ?? envNum('MEMORY_RANK_USAGE_WEIGHT', DEFAULT_RANKING.usageWeight),
+    importanceWeight:
+      input?.importanceWeight ?? envNum('MEMORY_RANK_IMPORTANCE_WEIGHT', DEFAULT_RANKING.importanceWeight),
+    halfLifeDays: input?.halfLifeDays ?? envNum('MEMORY_RANK_HALFLIFE_DAYS', DEFAULT_RANKING.halfLifeDays),
+  };
+}
+
 export const searchSchema = z.object({
   query: z.string().min(1),
   limit: z.number().int().min(1).max(100).optional(),
   types: z.array(z.enum(['learning', 'decision', 'entity', 'observation'])).optional(),
   mode: z.enum(['fts', 'vector', 'hybrid']).optional(),
+  // v2.3.0 scoping. `project` matches learnings/decisions whose project column
+  // equals it (entity/observation rows have no project and are excluded when a
+  // project filter is active). `tags` matches rows whose tags_json array
+  // contains ANY of the given tags (learnings/decisions only).
+  project: z.string().min(1).optional(),
+  tags: z.array(z.string().min(1)).min(1).optional(),
+  // v2.3.0 ranking-boost overrides (all optional, conservative defaults).
+  ranking: z
+    .object({
+      recencyWeight: z.number().min(0).max(1).optional(),
+      usageWeight: z.number().min(0).max(1).optional(),
+      importanceWeight: z.number().min(0).max(1).optional(),
+      halfLifeDays: z.number().positive().optional(),
+    })
+    .optional(),
 });
 
 interface SearchRow {
@@ -38,17 +103,71 @@ interface SearchRow {
   title: string;
   body: string;
   rank: number;
+  // v2.3.0 ranking signals, recovered from the source-table joins. Present for
+  // every row but only meaningful per type: usageCount + importance exist on
+  // learnings; recencyTs is the best per-type "freshness" timestamp.
+  usageCount?: number;
+  importance?: number | null;
+  recencyTs?: string | null;
+}
+
+/**
+ * Build the shared project/tags scoping predicate + its bound args (v2.3.0).
+ *
+ * The predicate references the source-table aliases the search queries already
+ * join (`l` = learnings, `d` = decisions). project/tags only exist on those two
+ * tables, so when either filter is active the predicate naturally excludes
+ * entity/observation rows (neither branch can match them) — "scope to project
+ * X" returns only project-X content, which is the least-surprising semantics.
+ *
+ * tags uses json_each (json1 is compiled into better-sqlite3) so a tag match is
+ * exact array-membership, not a fragile LIKE substring.
+ */
+function buildScopeClause(
+  project: string | undefined,
+  tags: string[] | undefined
+): { clause: string; args: unknown[] } {
+  const parts: string[] = [];
+  const args: unknown[] = [];
+
+  if (project !== undefined) {
+    parts.push(`(
+      (search_fts.content_type = 'learning' AND l.project = ?)
+      OR (search_fts.content_type = 'decision' AND d.project = ?)
+    )`);
+    args.push(project, project);
+  }
+
+  if (tags && tags.length > 0) {
+    const placeholders = tags.map(() => '?').join(',');
+    parts.push(`(
+      (search_fts.content_type = 'learning'
+        AND EXISTS (SELECT 1 FROM json_each(l.tags_json) WHERE value IN (${placeholders})))
+      OR (search_fts.content_type = 'decision'
+        AND EXISTS (SELECT 1 FROM json_each(d.tags_json) WHERE value IN (${placeholders})))
+    )`);
+    args.push(...tags, ...tags);
+  }
+
+  return { clause: parts.length > 0 ? `AND ${parts.join(' AND ')}` : '', args };
 }
 
 /**
  * FTS5/BM25 search — same query that powered v1.x. Extracted so the hybrid
  * path can reuse it as one half of the RRF fusion. Returns rows sorted by
  * BM25 rank ascending (smaller = better in FTS5).
+ *
+ * v2.3.0: the SELECT now also pulls the ranking signals (usage_count,
+ * importance, a per-type recency timestamp) and the query LEFT JOINs decisions
+ * + entities so the project/tags scope predicate and the boost have the columns
+ * they need.
  */
 function ftsSearch(
   query: string,
   types: string[] | undefined,
-  limit: number
+  limit: number,
+  project: string | undefined,
+  tags: string[] | undefined
 ): SearchRow[] {
   const db = getDb();
   const fts = escapeFtsQuery(query);
@@ -57,6 +176,8 @@ function ftsSearch(
     types && types.length > 0
       ? `AND search_fts.content_type IN (${types.map(() => '?').join(',')})`
       : '';
+
+  const scope = buildScopeClause(project, tags);
 
   // Two visibility gates, mirroring how the live entity views work:
   //   - archived learnings (archived = 1) never surface.
@@ -70,22 +191,36 @@ function ftsSearch(
            search_fts.content_type AS type,
            search_fts.title,
            search_fts.body,
-           bm25(search_fts) AS rank
+           bm25(search_fts) AS rank,
+           COALESCE(l.usage_count, 0) AS usageCount,
+           l.importance AS importance,
+           CASE search_fts.content_type
+             WHEN 'learning'    THEN COALESCE(l.last_used, l.date)
+             WHEN 'decision'    THEN d.date
+             WHEN 'observation' THEN COALESCE(eo.valid_from, eo.created_at)
+             WHEN 'entity'      THEN en.updated_at
+           END AS recencyTs
     FROM search_fts
     LEFT JOIN learnings l
       ON search_fts.content_type = 'learning' AND l.id = search_fts.content_id
+    LEFT JOIN decisions d
+      ON search_fts.content_type = 'decision' AND d.id = search_fts.content_id
     LEFT JOIN entity_observations eo
       ON search_fts.content_type = 'observation' AND eo.id = search_fts.content_id
+    LEFT JOIN entities en
+      ON search_fts.content_type = 'entity' AND en.id = search_fts.content_id
     WHERE search_fts MATCH ?
       AND (search_fts.content_type != 'learning' OR COALESCE(l.archived, 0) = 0)
       AND (search_fts.content_type != 'observation' OR eo.valid_to IS NULL)
       ${typeFilter}
+      ${scope.clause}
     ORDER BY rank
     LIMIT ?
   `;
 
   const args: unknown[] = [fts];
   if (types && types.length > 0) args.push(...types);
+  args.push(...scope.args);
   args.push(limit);
 
   return db.prepare(sql).all(...args) as SearchRow[];
@@ -105,11 +240,16 @@ function ftsSearch(
  * type-filter + archived-learnings filter in the outer query, and (4)
  * re-sort by distance and trim to `limit`. Over-fetching by ~4× covers the
  * typical case where the desired type makes up part of the index.
+ *
+ * v2.3.0: same source-table joins as ftsSearch so the scope predicate + the
+ * ranking-boost columns are available on the vector leg too.
  */
 function vectorSearch(
   vector: Float32Array,
   types: string[] | undefined,
-  limit: number
+  limit: number,
+  project: string | undefined,
+  tags: string[] | undefined
 ): SearchRow[] {
   const db = getDb();
 
@@ -137,6 +277,11 @@ function vectorSearch(
       ? `AND sfts.content_type IN (${types.map(() => '?').join(',')})`
       : '';
 
+  // The scope predicate is written against `search_fts.*` aliases; the vector
+  // query exposes the FTS row as `sfts`, so rewrite the alias for this leg.
+  const scopeRaw = buildScopeClause(project, tags);
+  const scopeClause = scopeRaw.clause.replace(/search_fts\./g, 'sfts.');
+
   const sql = `
     WITH vec_raw AS (
       SELECT content_id, distance
@@ -148,26 +293,78 @@ function vectorSearch(
            sfts.content_type AS type,
            sfts.title AS title,
            sfts.body AS body,
-           vr.distance AS rank
+           vr.distance AS rank,
+           COALESCE(l.usage_count, 0) AS usageCount,
+           l.importance AS importance,
+           CASE sfts.content_type
+             WHEN 'learning'    THEN COALESCE(l.last_used, l.date)
+             WHEN 'decision'    THEN d.date
+             WHEN 'observation' THEN COALESCE(eo.valid_from, eo.created_at)
+             WHEN 'entity'      THEN en.updated_at
+           END AS recencyTs
     FROM vec_raw vr
     LEFT JOIN search_fts sfts ON sfts.content_id = vr.content_id
     LEFT JOIN learnings l
       ON sfts.content_type = 'learning' AND l.id = vr.content_id
+    LEFT JOIN decisions d
+      ON sfts.content_type = 'decision' AND d.id = vr.content_id
     LEFT JOIN entity_observations eo
       ON sfts.content_type = 'observation' AND eo.id = vr.content_id
+    LEFT JOIN entities en
+      ON sfts.content_type = 'entity' AND en.id = vr.content_id
     WHERE sfts.content_id IS NOT NULL
       AND (sfts.content_type != 'learning' OR COALESCE(l.archived, 0) = 0)
       AND (sfts.content_type != 'observation' OR eo.valid_to IS NULL)
       ${typeFilter}
+      ${scopeClause}
     ORDER BY vr.distance
     LIMIT ?
   `;
 
   const args: unknown[] = [vector, overFetch];
   if (types && types.length > 0) args.push(...types);
+  args.push(...scopeRaw.args);
   args.push(limit);
 
   return db.prepare(sql).all(...args) as SearchRow[];
+}
+
+/**
+ * Compute the conservative ranking multiplier for a single fused row (v2.3.0).
+ *
+ * multiplier = 1
+ *   + recencyWeight    * exp(-ageDays / halfLifeDays)     // fresh > stale
+ *   + usageWeight      * usage_count / (usage_count + 5)  // used > unused (saturating)
+ *   + importanceWeight * clamp(importance, 0, 1)          // important > not
+ *
+ * Every term is >= 0, so the multiplier is always >= 1 — the boost can only
+ * lift a row, never sink it below its base RRF score. Missing signals
+ * contribute 0 (no recencyTs => no recency term, null importance => no
+ * importance term), so two rows with identical signals get the identical
+ * multiplier and their relative order is governed purely by the base RRF score
+ * (the equal-signals invariance the tests assert).
+ */
+function rankingMultiplier(row: SearchRow, opts: RankingOpts, nowMs: number): number {
+  let recency = 0;
+  if (row.recencyTs) {
+    // SQLite stores 'YYYY-MM-DD HH:MM:SS' (space, UTC, no zone). Normalise to an
+    // ISO instant so Date.parse is unambiguous across engines.
+    const iso = row.recencyTs.includes('T') ? row.recencyTs : row.recencyTs.replace(' ', 'T') + 'Z';
+    const ts = Date.parse(iso);
+    if (Number.isFinite(ts)) {
+      const ageDays = Math.max(0, (nowMs - ts) / 86_400_000);
+      recency = Math.exp(-ageDays / opts.halfLifeDays);
+    }
+  }
+
+  const usage = row.usageCount && row.usageCount > 0 ? row.usageCount / (row.usageCount + 5) : 0;
+
+  const importance =
+    row.importance != null && Number.isFinite(row.importance)
+      ? Math.min(1, Math.max(0, row.importance))
+      : 0;
+
+  return 1 + opts.recencyWeight * recency + opts.usageWeight * usage + opts.importanceWeight * importance;
 }
 
 /**
@@ -175,20 +372,26 @@ function vectorSearch(
  * summed over every ranker that saw it. k=60 is the canonical hybrid-search
  * constant. We then return the top-N by fused score with the metadata of
  * whichever ranker found it first.
+ *
+ * v2.3.0: after fusion we multiply each candidate's RRF score by a recency /
+ * usage / importance multiplier (rankingMultiplier) and re-sort. The boost is
+ * a no-op when `ranking` weights are all 0 or when every candidate shares the
+ * same signals — the relative order then collapses back to the pure RRF order.
  */
 function reciprocalRankFusion(
   rankings: SearchRow[][],
   k: number,
-  limit: number
+  limit: number,
+  ranking: RankingOpts
 ): SearchRow[] {
   const acc = new Map<
     string,
     { row: SearchRow; score: number }
   >();
 
-  for (const ranking of rankings) {
-    for (let i = 0; i < ranking.length; i++) {
-      const row = ranking[i];
+  for (const r of rankings) {
+    for (let i = 0; i < r.length; i++) {
+      const row = r[i];
       if (!row) continue;
       const key = `${row.type}:${row.id}`;
       const contribution = 1 / (k + i);
@@ -201,19 +404,25 @@ function reciprocalRankFusion(
     }
   }
 
-  const merged = Array.from(acc.values()).sort((a, b) => b.score - a.score);
+  const nowMs = Date.now();
+  const merged = Array.from(acc.values())
+    .map(({ row, score }) => ({ row, score: score * rankingMultiplier(row, ranking, nowMs) }))
+    .sort((a, b) => b.score - a.score);
+
   return merged.slice(0, limit).map(({ row, score }) => ({
     id: row.id,
     type: row.type,
     title: row.title,
     body: row.body,
-    rank: score, // RRF score — higher is better, unlike raw BM25/distance.
+    rank: score, // RRF score (boosted) — higher is better, unlike raw BM25/distance.
   }));
 }
 
 export async function search(input: z.infer<typeof searchSchema>): Promise<ToolResult> {
   const limit = input.limit ?? 20;
   const requestedMode = input.mode ?? 'hybrid';
+  const ranking = resolveRanking(input.ranking);
+  const { project, tags } = input;
 
   try {
     // Resolve effective mode based on what's actually available at runtime.
@@ -242,33 +451,39 @@ export async function search(input: z.infer<typeof searchSchema>): Promise<ToolR
 
     let rows: SearchRow[];
     if (effectiveMode === 'fts') {
-      rows = ftsSearch(input.query, input.types, limit);
+      rows = ftsSearch(input.query, input.types, limit, project, tags);
     } else if (effectiveMode === 'vector' && queryVector) {
-      rows = vectorSearch(queryVector, input.types, limit);
+      rows = vectorSearch(queryVector, input.types, limit, project, tags);
     } else if (effectiveMode === 'hybrid' && queryVector) {
       // Pull a wider candidate pool from each ranker than `limit`, so RRF has
       // enough overlap to be meaningful. 50 is the value Alex Garcia uses in
       // the canonical hybrid-search recipe.
       const candidatePool = Math.max(limit * 3, 50);
-      const ftsRows = ftsSearch(input.query, input.types, candidatePool);
-      const vecRows = vectorSearch(queryVector, input.types, candidatePool);
-      rows = reciprocalRankFusion([ftsRows, vecRows], 60, limit);
+      const ftsRows = ftsSearch(input.query, input.types, candidatePool, project, tags);
+      const vecRows = vectorSearch(queryVector, input.types, candidatePool, project, tags);
+      rows = reciprocalRankFusion([ftsRows, vecRows], 60, limit, ranking);
     } else {
       // Defensive: should be unreachable, but if state diverges we degrade.
-      rows = ftsSearch(input.query, input.types, limit);
+      rows = ftsSearch(input.query, input.types, limit, project, tags);
     }
+
+    // Trim the internal ranking-signal columns from the public payload — they
+    // are an implementation detail of the boost, not part of the result shape.
+    const results = rows.map((r) => ({ id: r.id, type: r.type, title: r.title, body: r.body, rank: r.rank }));
 
     return {
       success: true,
       data: {
         query: input.query,
-        results: rows,
-        count: rows.length,
+        results,
+        count: results.length,
         mode: effectiveMode,
         requestedMode,
+        ...(project ? { project } : {}),
+        ...(tags && tags.length > 0 ? { tags } : {}),
         ...(downgradeReason ? { notice: downgradeReason } : {}),
       },
-      message: `${rows.length} Ergebnisse für "${input.query}" (mode: ${effectiveMode}${downgradeReason ? `, requested ${requestedMode}` : ''}).`,
+      message: `${results.length} Ergebnisse für "${input.query}" (mode: ${effectiveMode}${downgradeReason ? `, requested ${requestedMode}` : ''}).`,
     };
   } catch (err) {
     return {


### PR DESCRIPTION
## What
Retrieval-quality + correctness improvements to the most-used local memory server in the suite. Built and adversarially reviewed before opening.

### Features
- **project / tags scoping** for `memory_search` + `memory_recall` (previously only insights/reflect could scope). Default (no filter) unchanged.
- **Recency / usage / importance ranking boost** in hybrid (RRF) search — the `importance` column was written but never read. Conservative (max +40%, tunable, cannot override a clear textual-relevance gap); single-mode fts/vector ordering untouched.

### Fixes
- **`memory_search({mode:"vector", types:["entity"]})` returned 0** — entities were never embedded. Now embed name + summary atomically on create/observe with summary-refresh + idempotent legacy backfill.
- **Contradiction scanner O(N^2) cap** (`maxObservationsPerEntity`, default 200) to avoid a quadratic cliff on long-lived entities.

### Quality
- `test:coverage` script + critical-path tests (RRF consensus, asOf window boundaries, supersede inverted-window, contradiction scope).
- `memory_recall` description clarified as FTS5-only.

### Verification
- Tests 194 -> **233** (+39); build + typecheck clean; no new `any`.
- Version bumped 2.2.0 -> 2.3.0 (package.json + SERVER_VERSION + CHANGELOG) to match the new MCP-visible params. **No npm publish in this PR.**