### PR TITLE
Fix memory_learn data loss + make test and build run on Windows

### DIFF
--- a/README.md
+++ b/README.md
@@ -204,7 +204,7 @@ memory_learn_archive({ learningId: "...", reason: "wrong" })
 memory_learn_update({ learningId: "...", content: "…", confidence: 0.9 })
 ```
 
-`archive` is a soft delete: the row stays in `learnings` (with `archived = 1`, `archived_at`, and `lifecycle_state = 'archived' | 'archived:<reason>'`), the embedding stays in vec0 (so asOf-style cross-references can still resolve), but `recall` / `search` / the gatekeeper's similarity check all filter it out. Idempotent.
+`archive` is a soft delete: the row stays in `learnings` (with `archived = 1`, `archived_at`, and `lifecycle_state = 'archived' | 'archived:<reason>'`), the embedding stays in vec0 (so asOf-style cross-references can still resolve), but `recall` / `search` / the duplicate check all filter it out. Idempotent.
 
 `update` edits a live (non-archived) learning. If `content` changes we re-embed in the F4 atomic pattern (compute outside the transaction, write inside one sync `db.transaction()`). If the embedding write fails or vec is disabled, the now-stale old embedding is purged so cosine search can't surface a vector that no longer represents the live text. Bumps `usage_count` and sets `last_used` so an edit counts as a touch.
 
@@ -237,7 +237,7 @@ The Markdown is for the LLM to read at session start; the structured fields are 
 
 ### Learnings
 
-**`memory_learn`** -- The core tool. Stores a piece of knowledge with a category and content. Categories: `pattern` (recurring success), `mistake` (what went wrong), `insight` (strategic realization), `research` (external knowledge), `architecture`, `infrastructure`, `tool`, `workflow`, `performance`, `security`. The duplicate gatekeeper checks if something similar already exists. If it finds a match, it bumps the usage counter instead of creating a duplicate. Optional: `tags`, `confidence` (0-1), `project`, `memoryType` (episodic or semantic, auto-classified if omitted).
+**`memory_learn`** -- The core tool. Stores a piece of knowledge with a category and content. Categories: `pattern` (recurring success), `mistake` (what went wrong), `insight` (strategic realization), `research` (external knowledge), `architecture`, `infrastructure`, `tool`, `workflow`, `performance`, `security`. The duplicate gatekeeper checks whether the identical content is already stored. If so, it bumps the usage counter instead of creating a duplicate. To extend an existing entry rather than add a new one, use `memory_learn_update` with its id. Optional: `tags`, `confidence` (0-1), `project`, `memoryType` (episodic or semantic, auto-classified if omitted).
 
 **`memory_recall`** -- Quick search on learnings only. Pass a `query` string for keyword search, or omit it to get the most recent learnings. Good for "what did I learn about X" questions. Use `limit` to control how many results come back (default 10).
 

--- a/WHITEPAPER.md
+++ b/WHITEPAPER.md
@@ -59,7 +59,7 @@ Developers and privacy-conscious users who want structured, searchable, long-ter
 
 **Sessions.** Each conversation can be started and ended; `memory_session_start` loads context from the last few sessions so the assistant resumes where you left off.
 
-**Learnings.** Typed knowledge entries (`pattern`, `mistake`, `insight`, `research`, `architecture`, `infrastructure`, `tool`, `workflow`, `performance`, `security`) with confidence, tags, and an episodic/semantic type that is auto-classified. A gatekeeper prevents duplicates: exact matches bump a usage counter; a much longer, very similar entry updates the existing one rather than forking it.
+**Learnings.** Typed knowledge entries (`pattern`, `mistake`, `insight`, `research`, `architecture`, `infrastructure`, `tool`, `workflow`, `performance`, `security`) with confidence, tags, and an episodic/semantic type that is auto-classified. A gatekeeper prevents duplicates: an exact match bumps a usage counter instead of storing the content twice. Enriching an existing entry is explicit, via `memory_learn_update` against its id, so a write never silently rewrites a row the caller did not name.
 
 **Decisions.** Strategic choices with reasoning and alternatives, so months later you can reconstruct *why* you chose something — not just what.
 

--- a/package.json
+++ b/package.json
@@ -50,11 +50,11 @@
     "url": "https://studiomeyer.io"
   },
   "scripts": {
-    "build": "tsc && cp src/db/schema.sql dist/db/schema.sql && mkdir -p dist/db/migrations && cp src/db/migrations/*.sql dist/db/migrations/ && chmod +x dist/server.js",
+    "build": "tsc && node scripts/copy-assets.mjs",
     "dev": "tsx src/server.ts",
-    "test": "MEMORY_EMBED_MOCK=1 vitest run",
-    "test:watch": "MEMORY_EMBED_MOCK=1 vitest",
-    "test:coverage": "MEMORY_EMBED_MOCK=1 vitest run --coverage",
+    "test": "vitest run",
+    "test:watch": "vitest",
+    "test:coverage": "vitest run --coverage",
     "typecheck": "tsc --noEmit",
     "prepublishOnly": "npm run build"
   },

--- a/scripts/copy-assets.mjs
+++ b/scripts/copy-assets.mjs
@@ -1,0 +1,21 @@
+/**
+ * Copy the SQL assets tsc does not emit, then mark the stdio entrypoint
+ * executable for the `bin` field.
+ *
+ * Replaces the `cp` / `mkdir -p` / `chmod` chain that used to live in the
+ * build script. npm runs scripts through cmd.exe on Windows, where none of
+ * those commands exist, so `npm run build` failed at the first `cp` after tsc
+ * had already emitted dist/ — leaving a dist without schema.sql, which then
+ * fails to bootstrap a fresh database.
+ */
+import { chmodSync, cpSync, mkdirSync, readdirSync } from 'node:fs';
+
+mkdirSync('dist/db/migrations', { recursive: true });
+cpSync('src/db/schema.sql', 'dist/db/schema.sql');
+
+for (const file of readdirSync('src/db/migrations').filter((n) => n.endsWith('.sql'))) {
+  cpSync(`src/db/migrations/${file}`, `dist/db/migrations/${file}`);
+}
+
+// No-op on Windows beyond the read-only bit, which is what we want.
+chmodSync('dist/server.js', 0o755);

--- a/src/tools/learn.test.ts
+++ b/src/tools/learn.test.ts
@@ -155,6 +155,147 @@ describe('learn gatekeeper', () => {
       }
     }
   });
+
+  it('never destroys an existing learning when storing a new one', async () => {
+    // Silent data loss: storing an unrelated learning REPLACES an existing
+    // one and reports action "updated_similar", which reads like success.
+    //
+    // Cause: the soft gatekeeper matches escapeFtsQuery(content.slice(0, 200))
+    // against `search_fts`. That helper ORs every token by design (docstring
+    // in src/db/client.ts), so ordinary words match almost any row; bm25() is
+    // an unbounded length-scaled score, not a normalised similarity; so the
+    // overwrite decision reduces to "the new entry is longer".
+    //
+    // The filler is not padding — bm25 is corpus-relative. With one stored
+    // document every matched token has IDF near zero: score -0.000008, so
+    // `score < -5` is unreachable. Measured here: 1 doc -0.000008, 6 docs
+    // -4.80, 11 docs -8.16. A suite storing two rows per case never sees it.
+    //
+    // The assertion names no victim. Which row bm25 ranks first is incidental;
+    // the contract is that storing one learning never removes or rewrites
+    // another. Every insert is therefore part of the act, leaving nothing for
+    // the defect to corrupt before the assertions run.
+    //
+    // By hand: restore the soft gatekeeper block in src/tools/learn.ts and
+    // re-run — two entries vanish, and the row holding the last document
+    // reports category "pattern" with empty tags.
+    const { learn } = await import('./learn.js');
+    const { getDb, escapeFtsQuery } = await import('../db/client.js');
+
+    const filler = [
+      'The build pipeline caches compiled artifacts between runs to avoid repeating work.',
+      'Feature flags are evaluated once per request and memoised for the duration.',
+      'Database migrations run forward only; rollbacks use a compensating migration.',
+      'The retry policy uses exponential backoff with jitter capped at thirty seconds.',
+      'Structured logs are emitted as newline delimited JSON for ingestion downstream.',
+      'Session cookies are marked secure, httponly, and samesite lax by default.',
+      'Static assets are fingerprinted so they can be cached indefinitely at the edge.',
+      'Background jobs are idempotent because the queue guarantees at least once delivery.',
+      'Connection pools are sized to the number of worker threads, not to peak traffic.',
+      'Timestamps are stored in UTC and converted only at the presentation layer.',
+      'The linter runs as a pre-commit hook and again in continuous integration.',
+      'Secrets are injected as environment variables and never written to disk.',
+      'Pagination uses an opaque cursor rather than an offset to stay stable under writes.',
+      'Health checks distinguish liveness from readiness so restarts are not triggered early.',
+      'Metrics are sampled at one percent for traces and one hundred percent for counters.',
+    ];
+    // Two longer notes on unrelated subjects, sharing no distinctive
+    // vocabulary. The last is more than 50 characters longer than the one
+    // before it, the shape the length heuristic reacts to.
+    const documents = [
+      ...filler.map((content) => ({ category: 'pattern' as const, tags: ['ops'], content })),
+      {
+        category: 'infrastructure' as const,
+        tags: ['packaging'],
+        content:
+          'A package manager that defers install scripts will print a warning and skip every install and postinstall hook until an operator approves them explicitly. Libraries that ship prebuilt platform binaries inside their published archive keep working regardless.',
+      },
+      {
+        category: 'architecture' as const,
+        tags: ['parsing'],
+        content:
+          'A template compiler stamps the name of the producing rule onto every node that rule returns. When a rule hands back a flat array of nodes it did not produce, those borrowed nodes lose their own provenance and any consumer mapping positions back to rules is misled. Returning a single wrapper that spans the whole region preserves the inner names, and wrapper instances must never be reused across nested regions because each reuse overwrites the match state of its parent.',
+      },
+    ];
+
+    // Record what each call REPORTED, not just what it did. The silence is
+    // half the defect: every one of these returns success.
+    const reportedAsMerged: string[] = [];
+    const store = async (doc: (typeof documents)[number]) => {
+      const result = await learn(doc);
+      expect(result.success, `learn() failed outright for: ${doc.content.slice(0, 40)}...`).toBe(true);
+      if (result.success && (result.data as { action: string }).action === 'updated_similar') {
+        reportedAsMerged.push(`"${doc.content.slice(0, 40)}..." returned success with action "updated_similar"`);
+      }
+    };
+
+    // All but the last, so the guard below inspects the corpus the final call
+    // will actually see.
+    for (const doc of documents.slice(0, -1)) {
+      await store(doc);
+    }
+
+    const db = getDb();
+    const last = documents[documents.length - 1]!;
+
+    // Precondition guard. Edit the corpus above and the score can drift back
+    // over the threshold, at which point the defect stops reproducing and this
+    // test would go green while the bug is still present. Fail loudly instead.
+    const candidate = db
+      .prepare(
+        `SELECT bm25(search_fts) AS score
+         FROM search_fts
+         JOIN learnings l ON l.id = search_fts.content_id
+         WHERE search_fts MATCH ? AND search_fts.content_type = 'learning'
+         AND l.archived = 0
+         ORDER BY score
+         LIMIT 1`
+      )
+      .get(escapeFtsQuery(last.content.slice(0, 200))) as { score: number } | undefined;
+    expect(
+      candidate?.score,
+      'corpus no longer reaches the gatekeeper threshold, so this test can no longer detect the defect'
+    ).toBeLessThan(-5);
+
+    await store(last);
+
+    const rows = db
+      .prepare('SELECT content, category, tags_json FROM learnings WHERE archived = 0')
+      .all() as Array<{ content: string; category: string; tags_json: string }>;
+
+    // Entries that are simply gone.
+    const destroyed = documents
+      .filter((d) => !rows.some((r) => r.content === d.content))
+      .map((d) => `"${d.content.slice(0, 40)}..." is gone`);
+
+    // Rows that survived carrying someone else's metadata. The UPDATE rewrites
+    // only `content`, so a row that absorbed another entry keeps the destroyed
+    // one's category and tags, which is what hides the corruption from
+    // tag-scoped search.
+    const wrongMetadata = documents
+      .map((doc) => {
+        const row = rows.find((r) => r.content === doc.content);
+        if (!row) return null; // already counted as destroyed
+        const tags = JSON.parse(row.tags_json) as string[];
+        const sameTags =
+          tags.length === doc.tags.length && tags.every((tag, i) => tag === doc.tags[i]);
+        if (row.category === doc.category && sameTags) return null;
+        return `"${doc.content.slice(0, 40)}..." was written as ${doc.category}/${JSON.stringify(doc.tags)} but its row reads ${row.category}/${row.tags_json}`;
+      })
+      .filter((entry): entry is string => entry !== null);
+
+    // One assertion carrying the whole defect, so a red run shows all three
+    // faces of it at once: the destruction, the success reported while
+    // destroying, and the metadata left describing content that no longer
+    // exists. Asserting these separately would hide the later ones, because
+    // the first failure ends the test.
+    expect({ destroyed, reportedAsMerged, wrongMetadata }).toEqual({
+      destroyed: [],
+      reportedAsMerged: [],
+      wrongMetadata: [],
+    });
+    expect(rows).toHaveLength(documents.length);
+  });
 });
 
 // ─── P3.3 v2.1.0 — learn_archive ──────────────────────

--- a/src/tools/learn.ts
+++ b/src/tools/learn.ts
@@ -74,49 +74,25 @@ export async function learn(input: z.infer<typeof learnSchema>): Promise<ToolRes
     };
   }
 
-  // Soft gatekeeper: FTS5 similarity check
-  try {
-    const fts = escapeFtsQuery(input.content.slice(0, 200));
-    const similar = db
-      .prepare(
-        `SELECT l.id, l.content, l.usage_count,
-                bm25(search_fts) AS score
-         FROM search_fts
-         JOIN learnings l ON l.id = search_fts.content_id
-         WHERE search_fts MATCH ? AND search_fts.content_type = 'learning'
-         AND l.archived = 0
-         ORDER BY score
-         LIMIT 1`
-      )
-      .get(fts) as { id: string; content: string; usage_count: number; score: number } | undefined;
-
-    // If the top match is very short and the new input is long, OR vice versa,
-    // treat as UPDATE (new, richer version of the same learning).
-    if (similar && similar.score < -5) {
-      const lenDiff = Math.abs(similar.content.length - input.content.length);
-      if (lenDiff > 50 && input.content.length > similar.content.length) {
-        // Atomic update: compute the new embedding outside the transaction,
-        // then UPDATE the row + write the embedding in one sync transaction.
-        const vec = await prepareEmbedding(input.content);
-        const tx = db.transaction(() => {
-          db.prepare(
-            'UPDATE learnings SET content = ?, usage_count = usage_count + 1, last_used = ?, confidence = ? WHERE id = ?'
-          ).run(input.content, nowIso(), input.confidence ?? 0.7, similar.id);
-          writeEmbeddingSync(db, similar.id, 'learning', vec);
-        });
-        tx();
-        return {
-          success: true,
-          data: { id: similar.id, action: 'updated_similar', usageCount: similar.usage_count + 1 },
-          message: 'Ähnliches Learning erweitert.',
-        };
-      }
-    }
-  } catch (err) {
-    // FTS5 query parsing failed — not fatal, just skip the similarity check.
-    // Log for debugging but continue with insert.
-    process.stderr.write(`[local-memory] FTS5 similarity check failed: ${err instanceof Error ? err.message : String(err)}\n`);
-  }
+  // A "soft gatekeeper" used to sit here: an FTS5 MATCH on the first 200
+  // characters, whose single best bm25() hit was overwritten when the new
+  // entry was more than 50 characters longer. It was removed because it
+  // destroyed unrelated learnings.
+  //
+  // The query was built with escapeFtsQuery, which ORs every token so that a
+  // search returns rows matching ANY of them. That is right for recall and
+  // wrong as the gate on a destructive write: ordinary words match almost
+  // every stored row. bm25() then ranks that near-universal candidate set, and
+  // because it is an unbounded, length-scaled relevance value rather than a
+  // normalised similarity, the fixed -5 threshold means different things at
+  // different corpus sizes. What remained of the decision was "the new entry
+  // is longer".
+  //
+  // A near-duplicate row is a small problem. Silently replacing an unrelated
+  // one is not, especially as the UPDATE rewrote only `content` and left
+  // category, tags and source describing text that no longer existed.
+  //
+  // Exact-duplicate detection above is unaffected and still bumps usage_count.
 
   // Atomic insert: compute embedding outside any transaction, then INSERT row
   // + INSERT embedding in one sync transaction. Either both commit or both

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,0 +1,11 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    // Deterministic 384-dim token-hash vectors instead of pulling the 120 MB
+    // multilingual-e5-small model into every run. Set here rather than as a
+    // shell prefix on the npm script so the suite also runs on Windows, where
+    // npm executes scripts through cmd.exe and `VAR=1 cmd` is a syntax error.
+    env: { MEMORY_EMBED_MOCK: '1' },
+  },
+});


### PR DESCRIPTION
Fixes #21.

This PR was created with the help of Claude Code running in VSCode extension.

Two fixes in one PR: `npm test` does not run on Windows without the first, so the data-loss test cannot be demonstrated there without it.

| Commit | Suite |
|---|---|
| 1. `fix(scripts)` make test and build run on Windows | green |
| 2. `test(learn)` add failing regression test for #21 | **red** |
| 3. `fix(learn)` stop memory_learn overwriting unrelated learnings | green |

Commit 2 is red by design: it fails, commit 3 passes. A bisect landing on commit 2 sees that failure.

### Data-loss fix

`escapeFtsQuery` ORs every token, so the duplicate query matches almost any stored row. `bm25()` is an unbounded relevance score, not a normalised similarity, so `< -5` is not a floor. The remaining decision is `input.content.length > similar.content.length`.

- `WHITEPAPER.md` promised "a much longer, **very similar** entry". No   similarity measure exists in the code.
- The heuristic is from v1.0.0, when no tool could edit a stored learning.
  `memory_learn_update` (v2.1.0) does that against a known id with an atomic re-embed.
- `learn_bulk` already excludes fuzzy merging: "not surprise merges that silently fold two distinct imported rows together".
- No test depended on it. `learn.test.ts:112` accepts either
  `updated_similar` or a fresh add.

Exact-duplicate detection is unchanged and still bumps `usage_count`.

Alternative, if automatic merging should stay: gate on the cosine already computed for `embeddings`. It is bounded and written on the same code path. Two constraints: it must fall back to `INSERT` when vectors are unavailable, not to FTS; and `sqlite-vec` currently fails to load, reported separately, so the gate would not fire until that is fixed.

### Windows fix

`npm` runs scripts through `cmd.exe`, which has no POSIX env-var prefix and no `cp`, `mkdir -p` or `chmod`. `npm test` and `npm run build` both fail. CI is `ubuntu-latest` only.

- `MEMORY_EMBED_MOCK` moves into a new `vitest.config.ts`
- the `cp`/`mkdir -p`/`chmod` chain becomes `scripts/copy-assets.mjs`, copying   only `*.sql` to match the previous glob
- no new dependencies

`tsc` emits `dist/` before `cp` fails, so the build leaves a `dist` without
`schema.sql`, which then fails to bootstrap a fresh database.

### Verification

| Platform | Node | Without fix | With fix |
|---|---|---|---|
| Windows 11 | 24.18.0 | 1 failed / 233 | 234 / 234 |
| Ubuntu 26.04 | 24.18.1 | 1 failed / 233 | 234 / 234 |
| Ubuntu 26.04 | 26.5.1 | 1 failed / 233 | 234 / 234 |

`tsc --noEmit` clean throughout. `npm run build` verified on both platforms; `dist/server.js` lands executable on Linux, matching the previous `chmod +x`. Node 20 and 22 are not verified. Node 24 is the overlap with your matrix.

The test seeds 15 documents. `bm25()` is corpus-relative: 1 document scores `-0.000008` and the branch cannot fire, 6 give `-4.80`, 11 give `-8.16`. A two-row test does not reproduce the defect. A precondition guard asserts the corpus still clears the threshold, so editing the fixture fails instead of passing while the defect remains.

The test names no victim. The damage cascades, so it asserts the contract:
storing one learning must never remove or rewrite another.

### Docs

`WHITEPAPER.md` and `README.md` updated to point at `memory_learn_update`.
`CHANGELOG.md` unchanged: its similarity-check mention is a v2.1.0 release
note.

The `memory_learn` entry in `README.md` was already inaccurate. It described a "similar" match as bumping the usage counter. That path overwrote the row; only exact duplicates bump it.

### Known gap

`scripts/copy-assets.mjs` has no test. Verifying its output requires the build to have run, so it does not fit vitest. A `test:smoke` script with a CI step after `npm run build` would cover it.
