### PR TITLE
fix(vector): make sqlite-vec load under ESM

### DIFF
--- a/src/db/vector.ts
+++ b/src/db/vector.ts
@@ -22,12 +22,16 @@
  */
 import type { Database } from 'better-sqlite3';
 import { readFileSync, existsSync } from 'node:fs';
+import { createRequire } from 'node:module';
 import { dirname, join } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { logger } from '../lib/logger.js';
 import { embed, embedBatch, EMBEDDING_DIM, embedModelId } from '../lib/embed.js';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
+
+// ESM has no `require`; the sqlite-vec loader below needs it.
+const require = createRequire(import.meta.url);
 
 let vectorEnabled = false;
 let lastError: string | null = null;


### PR DESCRIPTION
Fixes #23

This PR was created with help from Claude Code VSCode extension 

The package is `"type": "module"`, so `require` is undefined and the sqlite-vec load threw ReferenceError on every boot. The catch reported that as the platform lacking vec and degraded to FTS5-only, while the server still logged ready with 25 tools.

Recreate `require` with createRequire, beside the existing __dirname shim that solves the same problem in the same file. The loader, its catch and MEMORY_REQUIRE_VEC are untouched.

Verified from a clean build on Ubuntu 26.04 (Node 26.5.1) and Windows 11 (Node 24.18.0): boot logs "sqlite-vec extension loaded" instead of "sqlite-vec unavailable, FTS5-only mode: require is not defined". Suite 234/234.

No test: vitest runs the source through vite's transform, where require resolves, so the defect exists only in the built dist. Covering it needs a post-build harness.

