### PR TITLE
fix(messages): use English for all user-facing strings

### DIFF
--- a/src/tools/contradictions.ts
+++ b/src/tools/contradictions.ts
@@ -301,7 +301,7 @@ export function contradictions(input: z.infer<typeof contradictionsSchema>): Too
     },
     message:
       pairs.length === 0
-        ? 'Keine Widersprüche gefunden.'
-        : `${pairs.length} Widerspruch-Kandidat(en) gefunden.`,
+        ? 'No contradictions found.'
+        : `${pairs.length} contradiction candidate(s) found.`,
   };
 }

--- a/src/tools/decide.ts
+++ b/src/tools/decide.ts
@@ -76,6 +76,6 @@ export async function decide(input: z.infer<typeof decideSchema>): Promise<ToolR
   return {
     success: true,
     data: { id },
-    message: `Entscheidung "${input.title}" gespeichert.`,
+    message: `Decision "${input.title}" saved.`,
   };
 }

--- a/src/tools/entity.ts
+++ b/src/tools/entity.ts
@@ -65,7 +65,7 @@ function entityCreateInternal(
     return {
       success: true,
       data: { id: existing.id, action: 'existing' },
-      message: `Entity "${input.name}" existiert bereits.`,
+      message: `Entity "${input.name}" already exists.`,
     };
   }
 
@@ -82,7 +82,7 @@ function entityCreateInternal(
   return {
     success: true,
     data: { id, action: 'created' },
-    message: `Entity "${input.name}" (${input.entityType}) angelegt.`,
+    message: `Entity "${input.name}" (${input.entityType}) created.`,
   };
 }
 
@@ -176,7 +176,7 @@ export async function entityObserve(input: z.infer<typeof entityObserveSchema>):
   return {
     success: true,
     data: { observationId: id, entityId },
-    message: 'Beobachtung gespeichert.',
+    message: 'Observation saved.',
   };
 }
 
@@ -395,11 +395,11 @@ export function entityRelate(input: z.infer<typeof entityRelateSchema>): ToolRes
       `INSERT INTO entity_relations (id, from_entity_id, to_entity_id, relation_type, weight)
        VALUES (?, ?, ?, ?, ?)`
     ).run(id, input.fromEntityId, input.toEntityId, input.relationType, input.weight ?? 1.0);
-    return { success: true, data: { id }, message: 'Beziehung angelegt.' };
+    return { success: true, data: { id }, message: 'Relation created.' };
   } catch (err) {
     const msg = err instanceof Error ? err.message : String(err);
     if (msg.includes('UNIQUE')) {
-      return { success: false, error: 'Diese Beziehung existiert bereits.', code: 'DUPLICATE_RELATION' };
+      return { success: false, error: 'This relation already exists.', code: 'DUPLICATE_RELATION' };
     }
     return { success: false, error: msg, code: 'INSERT_FAILED' };
   }
@@ -437,7 +437,7 @@ export function entityDelete(input: z.infer<typeof entityDeleteSchema>): ToolRes
   });
   tx();
 
-  return { success: true, data: { id: input.id }, message: 'Entity und zugehörige Daten gelöscht.' };
+  return { success: true, data: { id: input.id }, message: 'Entity and its associated data deleted.' };
 }
 
 // ─── observation_supersede (v2.2.0) ──────────────────
@@ -489,7 +489,7 @@ export function observationSupersede(input: z.infer<typeof observationSupersedeS
     return {
       success: true,
       data: { observationId: older.id, entityId: older.entity_id, action: 'already_superseded', validTo: older.valid_to },
-      message: 'Beobachtung war bereits abgelöst.',
+      message: 'Observation was already superseded.',
     };
   }
 
@@ -542,6 +542,6 @@ export function observationSupersede(input: z.infer<typeof observationSupersedeS
         ? { note: 'validTo is at or before the observation valid_from — it will not be live at any point in time.' }
         : {}),
     },
-    message: 'Beobachtung abgelöst (Tombstone gesetzt, bleibt für asOf-Abfragen erhalten).',
+    message: 'Observation superseded (tombstone set; still reachable via asOf queries).',
   };
 }

--- a/src/tools/export.ts
+++ b/src/tools/export.ts
@@ -217,7 +217,7 @@ export function memoryExport(input: z.infer<typeof memoryExportSchema>): ToolRes
   return {
     success: true,
     data: envelope,
-    message: `Export: ${total} Datensätze (${learnings.length} learnings, ${decisions.length} decisions, ${entities.length} entities, ${observations.length} observations, ${relations.length} relations${includeSessions ? `, ${sessions.length} sessions` : ''}). Embeddings werden beim Import neu berechnet. Dieses Envelope ist auch von memory.studiomeyer.io importierbar.`,
+    message: `Export: ${total} records (${learnings.length} learnings, ${decisions.length} decisions, ${entities.length} entities, ${observations.length} observations, ${relations.length} relations${includeSessions ? `, ${sessions.length} sessions` : ''}). Embeddings are recomputed on import. This envelope also imports into memory.studiomeyer.io.`,
   };
 }
 
@@ -507,7 +507,7 @@ export async function memoryImport(input: z.infer<typeof memoryImportSchema>): P
   return {
     success: true,
     data: { imported: counts, skipped, mode: 'merge' },
-    message: `Import: ${totalImported} neue Datensätze übernommen (additiv, Duplikate übersprungen).${totalSkipped > 0 ? ` ${totalSkipped} übersprungen (fehlende Referenzen/fehlerhaft).` : ''}`,
+    message: `Import: ${totalImported} new records added (additive, duplicates skipped).${totalSkipped > 0 ? ` ${totalSkipped} skipped (missing references or malformed).` : ''}`,
   };
 }
 

--- a/src/tools/insights.ts
+++ b/src/tools/insights.ts
@@ -60,7 +60,7 @@ export function insights(input: z.infer<typeof insightsSchema>): ToolResult {
       categoryBreakdown,
       entityTypeBreakdown,
     },
-    message: `Claude kennt dich seit ${daysOfMemory} Tagen. Er erinnert sich an ${totalLearnings} Dinge.`,
+    message: `Claude has known you for ${daysOfMemory} days and remembers ${totalLearnings} things.`,
   };
 }
 
@@ -108,7 +108,7 @@ export function health(): ToolResult {
       },
     },
     message: integrity === 'ok'
-      ? `Alles gesund. Hybrid: ${vec.enabled && embedMode() !== 'disabled' ? 'on' : 'off (FTS5-only)'}.`
+      ? `All healthy. Hybrid: ${vec.enabled && embedMode() !== 'disabled' ? 'on' : 'off (FTS5-only)'}.`
       : `Integrity issue: ${integrity}`,
   };
 }
@@ -148,7 +148,7 @@ export function profile(input: z.infer<typeof profileSchema>): ToolResult {
     `profile_${input.field}`,
     input.value
   );
-  return { success: true, data: { field: input.field, value: input.value }, message: 'Profil aktualisiert.' };
+  return { success: true, data: { field: input.field, value: input.value }, message: 'Profile updated.' };
 }
 
 // ─── goal ────────────────────────────────────────────
@@ -168,10 +168,10 @@ export function goal(input: z.infer<typeof goalSchema>): ToolResult {
   if (input.action === 'set') {
     if (!input.goal) return { success: false, error: 'goal required for set.', code: 'MISSING_ARGS' };
     db.prepare('INSERT OR REPLACE INTO meta (key, value) VALUES (?, ?)').run('current_goal', input.goal);
-    return { success: true, data: { goal: input.goal }, message: 'Ziel gesetzt.' };
+    return { success: true, data: { goal: input.goal }, message: 'Goal set.' };
   }
   db.prepare("DELETE FROM meta WHERE key = 'current_goal'").run();
-  return { success: true, data: { goal: null }, message: 'Ziel gelöscht.' };
+  return { success: true, data: { goal: null }, message: 'Goal cleared.' };
 }
 
 // ─── guide ───────────────────────────────────────────

--- a/src/tools/learn.ts
+++ b/src/tools/learn.ts
@@ -75,7 +75,7 @@ export async function learn(input: z.infer<typeof learnSchema>): Promise<ToolRes
     return {
       success: true,
       data: { id: exact.id, action: 'skipped_duplicate', usageCount: exact.usage_count + 1 },
-      message: 'Duplikat erkannt — Usage-Counter erhöht.',
+      message: 'Duplicate detected; usage counter incremented.',
     };
   }
 
@@ -129,7 +129,7 @@ export async function learn(input: z.infer<typeof learnSchema>): Promise<ToolRes
   return {
     success: true,
     data: { id, action: 'added', memoryType },
-    message: 'Learning gespeichert.',
+    message: 'Learning saved.',
   };
 }
 
@@ -174,7 +174,7 @@ export function learnArchive(input: z.infer<typeof learnArchiveSchema>): ToolRes
     return {
       success: true,
       data: { id: input.learningId, action: 'already_archived' },
-      message: 'Learning war bereits archiviert.',
+      message: 'Learning was already archived.',
     };
   }
 
@@ -196,8 +196,8 @@ export function learnArchive(input: z.infer<typeof learnArchiveSchema>): ToolRes
     success: true,
     data: { id: input.learningId, action: 'archived', lifecycleState: lifecycle },
     message: input.reason
-      ? `Learning archiviert: ${input.reason}.`
-      : 'Learning archiviert.',
+      ? `Learning archived: ${input.reason}.`
+      : 'Learning archived.',
   };
 }
 
@@ -304,7 +304,7 @@ export async function learnUpdate(input: z.infer<typeof learnUpdateSchema>): Pro
       reembedded: willChangeContent && vec !== null,
       contentChanged: willChangeContent,
     },
-    message: 'Learning aktualisiert.',
+    message: 'Learning updated.',
   };
 }
 
@@ -433,7 +433,7 @@ export async function learnBulk(input: z.infer<typeof learnBulkSchema>): Promise
   return {
     success: true,
     data: { total: input.items.length, added, skipped, results },
-    message: `${added} Learnings hinzugefügt, ${skipped} Duplikate übersprungen.`,
+    message: `${added} learnings added, ${skipped} duplicates skipped.`,
   };
 }
 

--- a/src/tools/reflect.ts
+++ b/src/tools/reflect.ts
@@ -274,7 +274,7 @@ export function reflect(input: z.infer<typeof reflectSchema>): ToolResult {
       openDecisions,
       summary,
     },
-    message: `Reflection für die letzten ${lookback} Tage.`,
+    message: `Reflection over the last ${lookback} days.`,
   };
 }
 

--- a/src/tools/search.ts
+++ b/src/tools/search.ts
@@ -483,7 +483,7 @@ export async function search(input: z.infer<typeof searchSchema>): Promise<ToolR
         ...(tags && tags.length > 0 ? { tags } : {}),
         ...(downgradeReason ? { notice: downgradeReason } : {}),
       },
-      message: `${results.length} Ergebnisse für "${input.query}" (mode: ${effectiveMode}${downgradeReason ? `, requested ${requestedMode}` : ''}).`,
+      message: `${results.length} results for "${input.query}" (mode: ${effectiveMode}${downgradeReason ? `, requested ${requestedMode}` : ''}).`,
     };
   } catch (err) {
     return {

--- a/src/tools/session.test.ts
+++ b/src/tools/session.test.ts
@@ -159,7 +159,7 @@ describe('sessionStart', () => {
     const result = sessionStart({});
     if (result.success) {
       // The message should still exist but not mention an empty project.
-      expect(result.message).not.toContain('Projekt:');
+      expect(result.message).not.toContain('Project:');
     }
   });
 });

--- a/src/tools/session.ts
+++ b/src/tools/session.ts
@@ -63,7 +63,7 @@ export function sessionStart(input: z.infer<typeof sessionStartSchema>): ToolRes
       previousSessions: prevSessions,
       recentLearnings,
     },
-    message: `Session #${totalSessions} gestartet.${input.project ? ` Projekt: ${input.project}` : ''}`,
+    message: `Session #${totalSessions} started.${input.project ? ` Project: ${input.project}` : ''}`,
   };
 }
 
@@ -100,6 +100,6 @@ export function sessionEnd(input: z.infer<typeof sessionEndSchema>): ToolResult 
   return {
     success: true,
     data: { sessionId: targetId },
-    message: 'Session beendet.',
+    message: 'Session ended.',
   };
 }


### PR DESCRIPTION
- Fixes #25

This PR was created with the help of Claude Code.

The message and error values returned to the MCP client were 26 English to 26 German, and 15 of the German ones contained English, for example "Export: N Datensätze (N learnings, N decisions, N entities)".

* Translate 29 literals across 9 files, following the English strings already present
* Update the session test asserting not.toContain("Projekt:"), which would otherwise pass while testing nothing
* Leave tools/registry.ts untouched; its tool descriptions were already English

No behaviour change.

## Checklist

Locally tested on **Windows only**

- [x] Tests pass
- [x] Build succeeds
- [x] No breaking changes
